### PR TITLE
Feature/refactor settings wearables screen

### DIFF
--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsFragment.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsFragment.kt
@@ -210,7 +210,7 @@ class WearablesSettingsFragment : BaseAppCompatFragment(R.layout.fragment_blueto
                     adapter.notifyTimerUpdate(item.timerItem.item, item.remainingMillis)
                 }
                 TimerViewModel.State.AllItemsFinished -> {
-                    wearablesSettingsViewModel.getStoredWearables()
+                    wearablesSettingsViewModel.fetchWearables()
                 }
             }
         }

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsFragment.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsFragment.kt
@@ -3,9 +3,11 @@
  */
 package com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables
 
-import android.content.DialogInterface
 import android.os.Bundle
-import android.view.*
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -15,14 +17,16 @@ import com.launchkey.android.authenticator.sdk.ui.AuthenticatorUIManager
 import com.launchkey.android.authenticator.sdk.ui.R
 import com.launchkey.android.authenticator.sdk.ui.databinding.FragmentBluetoothSettingsBinding
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.ItemAdapter
+import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.SettingsPanel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.TimerViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.VerificationFlagViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.common.TimeAgo
 import com.launchkey.android.authenticator.sdk.ui.internal.dialog.AlertDialogFragment
-import com.launchkey.android.authenticator.sdk.ui.internal.dialog.DialogFragmentViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.dialog.GenericAlertDialogFragment
 import com.launchkey.android.authenticator.sdk.ui.internal.dialog.ProgressDialogFragment
-import com.launchkey.android.authenticator.sdk.ui.internal.util.*
+import com.launchkey.android.authenticator.sdk.ui.internal.util.BaseAppCompatFragment
+import com.launchkey.android.authenticator.sdk.ui.internal.util.UiUtils
+import com.launchkey.android.authenticator.sdk.ui.internal.util.viewBinding
 
 class WearablesSettingsFragment : BaseAppCompatFragment(R.layout.fragment_bluetooth_settings) {
     companion object {
@@ -30,182 +34,227 @@ class WearablesSettingsFragment : BaseAppCompatFragment(R.layout.fragment_blueto
         private const val REMOVE_SINGLE_TAG = "REMOVE_SINGLE_TAG"
     }
 
-    private val binding: FragmentBluetoothSettingsBinding by viewBinding(FragmentBluetoothSettingsBinding::bind)
-    private val wearablesSettingsViewModel: WearablesSettingsViewModel by viewModels({ requireParentFragment() })
-    private val verificationFlagViewModel: VerificationFlagViewModel by lazy { ViewModelProvider(this).get(VerificationFlagViewModel.WEARABLES, VerificationFlagViewModel::class.java) }
-    private val timerViewModel: TimerViewModel by viewModels()
-    private var loadingDialog: ProgressDialogFragment? = null
-    private val confirmRemoveDialog: AlertDialogFragment?
-        get() = childFragmentManager.findFragmentByTag(REMOVE_SINGLE_TAG) as? AlertDialogFragment
-    private val confirmRemoveSingleDialogViewModel: DialogFragmentViewModel by lazy { ViewModelProvider(this, defaultViewModelProviderFactory).get(REMOVE_SINGLE_TAG, DialogFragmentViewModel::class.java) }
-    private val confirmRemoveAllDialogViewModel: DialogFragmentViewModel by lazy { ViewModelProvider(this, defaultViewModelProviderFactory).get(REMOVE_ALL_TAG, DialogFragmentViewModel::class.java) }
-    private val yesClick = SingleRemoveDialogListener()
+    private lateinit var settingsPanel: SettingsPanel
+    private val binding by viewBinding(FragmentBluetoothSettingsBinding::bind)
     private val adapter: ItemAdapter<WearablesManager.Wearable>
         get() = binding.bluetoothSettingsList.adapter as ItemAdapter<WearablesManager.Wearable>
-
-    private inner class SingleRemoveDialogListener : DialogInterface.OnClickListener {
-        lateinit var wearable: WearablesManager.Wearable
-        override fun onClick(dialog: DialogInterface?, which: Int) {
-            if (confirmRemoveDialog == null) return
-            if (wearable.isPendingRemoval) {
-                wearablesSettingsViewModel.cancelRemoveWearable(wearable)
-            } else {
-                wearablesSettingsViewModel.removeWearable(wearable)
-            }
-        }
+    private val wearablesSettingsViewModel: WearablesSettingsViewModel by viewModels({ requireParentFragment() })
+    private val verificationFlagViewModel: VerificationFlagViewModel by lazy {
+        ViewModelProvider(this).get(
+            VerificationFlagViewModel.WEARABLES,
+            VerificationFlagViewModel::class.java
+        )
     }
+    private val timerViewModel: TimerViewModel by viewModels()
+
+    private val loadingDialogFragment: ProgressDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(ProgressDialogFragment::class.java.simpleName) as? ProgressDialogFragment
+    private val removeSingleWearableDialogFragment: AlertDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(REMOVE_SINGLE_TAG) as? AlertDialogFragment
+    private val removeAllWearablesDialogFragment: AlertDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(REMOVE_ALL_TAG) as? AlertDialogFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.bluetooth_add, menu);
-        super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.bluetooth_add, menu)
+        super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.bluetooth_add -> {
+                wearablesSettingsViewModel.requestNewWearable()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val onRemoveAllListener = View.OnClickListener { confirmRemoveAllDialogViewModel.changeState(DialogFragmentViewModel.State.NeedsToBeShown) }
-        confirmRemoveAllDialogViewModel.state.observe(viewLifecycleOwner) { state ->
-            if (state is DialogFragmentViewModel.State.NeedsToBeShown) {
-                GenericAlertDialogFragment.show(childFragmentManager,
-                        requireContext(),
-                        getString(R.string.ioa_sec_bp_sett_dialog_remove_all_title),
-                        getString(R.string.ioa_sec_bp_sett_dialog_remove_all_messsage),
-                        getString(R.string.ioa_generic_yes),
-                        true,
-                        getString(R.string.ioa_generic_cancel),
-                        REMOVE_ALL_TAG)
-                confirmRemoveAllDialogViewModel.changeState(DialogFragmentViewModel.State.Shown)
-            } else if (state is DialogFragmentViewModel.State.Shown) {
-                val yesClick = DialogInterface.OnClickListener { dialog, which ->
-                    wearablesSettingsViewModel.removeAllWearables()
-                }
-                val removeAllDialog = childFragmentManager.findFragmentByTag(REMOVE_ALL_TAG) as AlertDialogFragment?
-                removeAllDialog!!.setPositiveButtonClickListener(yesClick)
+        setupSettingsPanel()
+        setupWearablesList()
+        subscribeObservers()
+
+        removeSingleWearableDialogFragment?.setPositiveButtonClickListener { _, _ ->
+            wearablesSettingsViewModel.removeSelectedWearable()
+        }
+        removeAllWearablesDialogFragment?.setPositiveButtonClickListener { _, _ ->
+            wearablesSettingsViewModel.removeAllWearables()
+        }
+    }
+
+    private fun setupSettingsPanel() {
+        settingsPanel = binding.bluetoothSettingsPanel.apply {
+            setRemoveText(R.string.ioa_sec_bp_sett_panel_remove_text)
+            setRemoveButtonText(R.string.ioa_sec_bp_sett_panel_remove_button)
+            setVerifiedWhenText(R.string.ioa_sec_panel_verify_always)
+            setOnRemoveButtonClick {
+                wearablesSettingsViewModel.requestRemoveAllWearables()
+            }
+            disallowSwitchSwipe()
+            setOnSwitchClickedListener {
+                verificationFlagViewModel.toggleVerificationFlag(
+                    if (isSwitchOn) VerificationFlag.State.ALWAYS
+                    else VerificationFlag.State.WHEN_REQUIRED
+                )
             }
         }
+    }
 
+    private fun setupWearablesList() {
         binding.bluetoothSettingsList.adapter = ItemAdapter<WearablesManager.Wearable>(
-                AuthenticatorUIManager.instance.config.themeObj(),
-                TimeAgo(requireContext()),
-                R.string.ioa_calabash_sett_remove_wear_item_format,
-                R.drawable.ic_bluetooth_black_24dp
+            AuthenticatorUIManager.instance.config.themeObj(),
+            TimeAgo(requireContext()),
+            R.string.ioa_calabash_sett_remove_wear_item_format,
+            R.drawable.ic_bluetooth_black_24dp
         ) { wearableToRemove ->
-            yesClick.wearable = wearableToRemove.item
-            confirmRemoveSingleDialogViewModel.changeState(DialogFragmentViewModel.State.NeedsToBeShown)
-
+            wearablesSettingsViewModel.setWearableToRemove(wearableToRemove.item)
         }
-        binding.bluetoothSettingsList.layoutManager = LinearLayoutManager(requireContext())
         binding.bluetoothSettingsList.setHasFixedSize(true)
-        confirmRemoveSingleDialogViewModel.state.observe(viewLifecycleOwner) { state ->
-            when (state) {
-                DialogFragmentViewModel.State.NeedsToBeShown -> {
-                    val item = yesClick.wearable
-                    val pendingRemoval = item.isPendingRemoval
-                    val name = item.name
-                    val header = if (pendingRemoval) getString(R.string.ioa_sec_bp_sett_dialog_undoremove_single_title) else getString(R.string.ioa_sec_bp_sett_dialog_remove_single_title)
-                    val message = if (pendingRemoval) getString(R.string.ioa_sec_bp_sett_dialog_undoremoval_message_format, name) else getString(R.string.ioa_sec_bp_sett_dialog_remove_single_message_format, name)
-                    GenericAlertDialogFragment.show(childFragmentManager,
-                            requireContext(),
-                            header,
-                            message,
-                            getString(R.string.ioa_generic_yes),
-                            true,
-                            getString(R.string.ioa_generic_cancel),
-                            REMOVE_SINGLE_TAG)
-                    confirmRemoveSingleDialogViewModel.changeState(DialogFragmentViewModel.State.Shown)
-                }
-                DialogFragmentViewModel.State.Shown -> {
-                    confirmRemoveDialog?.setPositiveButtonClickListener(yesClick)
-                }
-            }
-        }
-        loadingDialog = ProgressDialogFragment.newInstance(null, getString(R.string.ioa_sec_bp_sett_loading), false, true)
+        binding.bluetoothSettingsList.layoutManager = LinearLayoutManager(requireContext())
+    }
 
-        val settingsPanel = binding.bluetoothSettingsPanel
-
-        wearablesSettingsViewModel.getStoredWearablesState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesSettingsViewModel.GetStoredWearablesState.Success -> {
-                    timerViewModel.stopTimers()
-                    adapter.submitList(it.wearables)
-                    adapter.notifyDataSetChanged()
-                    loadingDialog!!.dismiss()
-                    val timerItems: List<TimerViewModel.TimerItem<WearableItem>> =
-                            it.wearables.mapNotNull { wearableItem ->
-                                when (wearableItem.pendingState) {
-                                    ItemAdapter.ItemPendingState.NotPending -> null
-                                    is ItemAdapter.ItemPendingState.PendingActivation -> TimerViewModel.TimerItem(
-                                            wearableItem,
-                                            (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingActivation).activatedAtTimeInMillis
-                                    )
-                                    is ItemAdapter.ItemPendingState.PendingRemoval -> TimerViewModel.TimerItem(
-                                            wearableItem,
-                                            (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingRemoval).removedAtTimeInMillis
-                                    )
-                                }
-                            }
-
-                    timerViewModel.startTimers(timerItems)
-                }
-                is WearablesSettingsViewModel.GetStoredWearablesState.Failure -> requireActivity().onBackPressed()
-            }
-        }
-
+    private fun subscribeObservers() {
         verificationFlagViewModel.verificationFlag.observe(viewLifecycleOwner) { verificationFlagState ->
             when (verificationFlagState) {
                 is VerificationFlagViewModel.VerificationFlagState.Failed -> requireActivity().finish()
                 VerificationFlagViewModel.VerificationFlagState.FetchingVerificationFlag -> Unit
                 is VerificationFlagViewModel.VerificationFlagState.Pending -> UiUtils.updateSettingsPanelWithFactorState(
-                        settingsPanel,
-                        verificationFlagState.verificationFlag,
-                        verificationFlagState.millisUntilToggled,
-                        false
+                    settingsPanel,
+                    verificationFlagState.verificationFlag,
+                    verificationFlagState.millisUntilToggled,
+                    false
                 )
                 is VerificationFlagViewModel.VerificationFlagState.GotVerificationFlag -> {
                     UiUtils.updateSettingsPanelWithFactorState(
-                            settingsPanel,
-                            verificationFlagState.verificationFlag,
-                            0,
-                            false
+                        settingsPanel,
+                        verificationFlagState.verificationFlag,
+                        0,
+                        false
                     )
                 }
             }
         }
 
-        wearablesSettingsViewModel.cancelRemoveState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesSettingsViewModel.CancelRemoveState.Success -> {
-                    timerViewModel.cancelTimerForItem(it.wearable)
+        wearablesSettingsViewModel.getStoredWearablesState.observe(viewLifecycleOwner) { fetchWearablesState ->
+            loadingDialogFragment?.dismiss()
+            when (fetchWearablesState) {
+                is WearablesSettingsViewModel.GetStoredWearablesState.GotStoredWearables -> {
+                    timerViewModel.stopTimers()
+                    adapter.submitList(fetchWearablesState.wearables)
+                    val timerItems: List<TimerViewModel.TimerItem<WearableItem>> =
+                        fetchWearablesState.wearables.mapNotNull { wearableItem ->
+                            when (wearableItem.pendingState) {
+                                ItemAdapter.ItemPendingState.NotPending -> null
+                                is ItemAdapter.ItemPendingState.PendingActivation -> TimerViewModel.TimerItem(
+                                    wearableItem,
+                                    (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingActivation).activatedAtTimeInMillis
+                                )
+                                is ItemAdapter.ItemPendingState.PendingRemoval -> TimerViewModel.TimerItem(
+                                    wearableItem,
+                                    (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingRemoval).removedAtTimeInMillis
+                                )
+                            }
+                        }
+
+                    timerViewModel.startTimers(timerItems)
                 }
-                is WearablesSettingsViewModel.CancelRemoveState.Failure -> requireActivity().onBackPressed()
+                WearablesSettingsViewModel.GetStoredWearablesState.GettingStoredWearables -> {
+                    if (loadingDialogFragment == null) {
+                        ProgressDialogFragment.show(
+                            null,
+                            getString(R.string.ioa_sec_bp_sett_loading),
+                            cancellable = false,
+                            indeterminate = false,
+                            childFragmentManager,
+                            ProgressDialogFragment::class.java.simpleName
+                        )
+                    }
+                }
+                else -> Unit
             }
         }
 
-        wearablesSettingsViewModel.removeState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesSettingsViewModel.RemoveState.Success -> { /* getStoredWearables() called from dialog to refresh list */ }
-                is WearablesSettingsViewModel.RemoveState.Failure -> requireActivity().onBackPressed()
+        wearablesSettingsViewModel.newWearableState.observe(viewLifecycleOwner) { newWearableState ->
+            when (newWearableState) {
+                WearablesSettingsViewModel.NewWearableState.AddingNewWearable -> {
+                    timerViewModel.stopTimers()
+                }
+                else -> Unit
             }
         }
 
-        wearablesSettingsViewModel.removeAllState.observe(viewLifecycleOwner) {
-            // Go back regardless
-            requireActivity().onBackPressed()
+        wearablesSettingsViewModel.removeSingleWearableState.observe(viewLifecycleOwner) { removeSingleWearableState ->
+            when (removeSingleWearableState) {
+                is WearablesSettingsViewModel.RemoveSingleWearableState.CancelledWearableRemoval -> {
+                    timerViewModel.cancelTimerForItem(removeSingleWearableState.wearable)
+                }
+                is WearablesSettingsViewModel.RemoveSingleWearableState.RemovingWearable -> {
+                    val wearableToRemove = removeSingleWearableState.wearable
+                    val header: String
+                    val message: String
+                    if (wearableToRemove.isPendingRemoval) {
+                        header = getString(R.string.ioa_sec_bp_sett_dialog_undoremove_single_title)
+                        message = getString(
+                            R.string.ioa_sec_bp_sett_dialog_undoremoval_message_format,
+                            wearableToRemove.name
+                        )
+                    } else {
+                        header = getString(R.string.ioa_sec_bp_sett_dialog_remove_single_title)
+                        message = getString(
+                            R.string.ioa_sec_bp_sett_dialog_remove_single_message_format,
+                            wearableToRemove.name
+                        )
+                    }
+
+                    GenericAlertDialogFragment.show(
+                        childFragmentManager,
+                        requireContext(),
+                        header,
+                        message,
+                        getString(R.string.ioa_generic_yes),
+                        true,
+                        getString(R.string.ioa_generic_cancel),
+                        REMOVE_SINGLE_TAG
+                    ).setPositiveButtonClickListener { _, _ ->
+                        wearablesSettingsViewModel.removeSelectedWearable()
+                    }
+                }
+                else -> Unit
+            }
+        }
+
+        wearablesSettingsViewModel.removeAllWearablesState.observe(viewLifecycleOwner) { removeAllWearablesState ->
+            if (removeAllWearablesState is WearablesSettingsViewModel.RemoveAllWearablesState.RemovingAllWearables) {
+                GenericAlertDialogFragment.show(
+                    childFragmentManager,
+                    requireContext(),
+                    getString(R.string.ioa_sec_bp_sett_dialog_remove_all_title),
+                    getString(R.string.ioa_sec_bp_sett_dialog_remove_all_messsage),
+                    getString(R.string.ioa_generic_yes),
+                    true,
+                    getString(R.string.ioa_generic_cancel),
+                    REMOVE_ALL_TAG
+                ).setPositiveButtonClickListener { _, _ ->
+                    wearablesSettingsViewModel.removeAllWearables()
+                }
+            }
         }
 
         timerViewModel.state.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is TimerViewModel.State.ItemFinished<*> -> {
-                    // remove or activate the location
+                    // remove or activate the wearable
                     val item = state as TimerViewModel.State.ItemFinished<WearableItem>
                     adapter.notifyTimerFinished(item.timerItem.item)
                 }
                 is TimerViewModel.State.ItemUpdated<*> -> {
-                    // update the location
+                    // update the wearable
                     val item = state as TimerViewModel.State.ItemUpdated<WearableItem>
                     adapter.notifyTimerUpdate(item.timerItem.item, item.remainingMillis)
                 }
@@ -214,29 +263,5 @@ class WearablesSettingsFragment : BaseAppCompatFragment(R.layout.fragment_blueto
                 }
             }
         }
-
-        with(settingsPanel) {
-            setRemoveText(R.string.ioa_sec_bp_sett_panel_remove_text)
-            setRemoveButtonText(R.string.ioa_sec_bp_sett_panel_remove_button)
-            setOnRemoveButtonClick(onRemoveAllListener)
-            disallowSwitchSwipe()
-            setOnSwitchClickedListener {
-                verificationFlagViewModel.toggleVerificationFlag(
-                        if (isSwitchOn) VerificationFlag.State.ALWAYS
-                        else VerificationFlag.State.WHEN_REQUIRED
-                )
-            }
-        }
-        loadingDialog!!.show(childFragmentManager, ProgressDialogFragment::class.java.simpleName)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val id = item.itemId
-        if (R.id.bluetooth_add == id) {
-            // TODO: 10/15/21 don't call parent fragments method
-            (requireParentFragment() as WearablesFragment).goToAdd(true)
-            return true
-        }
-        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsViewModel.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsViewModel.kt
@@ -5,10 +5,7 @@ import com.launchkey.android.authenticator.sdk.core.auth_method_management.Weara
 import com.launchkey.android.authenticator.sdk.ui.internal.util.TimingCounter
 import com.launchkey.android.authenticator.sdk.ui.internal.util.disposeWhenCancelled
 import com.launchkey.android.authenticator.sdk.ui.internal.viewmodel.SingleLiveEvent
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.*
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -18,24 +15,30 @@ class WearablesSettingsViewModel(
     private val defaultDispatcher: CoroutineDispatcher,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
-    private val _getStoredWearablesState: MutableLiveData<GetStoredWearablesState> =
-        MutableLiveData()
-    val getStoredWearablesState: LiveData<GetStoredWearablesState> = _getStoredWearablesState
+    private val _newWearableState = SingleLiveEvent<NewWearableState>()
+    val newWearableState: LiveData<NewWearableState>
+        get() = _newWearableState
 
-    private val _cancelRemoveState: MutableLiveData<CancelRemoveState> = SingleLiveEvent()
-    val cancelRemoveState: LiveData<CancelRemoveState> = _cancelRemoveState
+    private val _getStoredWearablesState = MutableLiveData<GetStoredWearablesState>()
+    val getStoredWearablesState: LiveData<GetStoredWearablesState>
+        get() = _getStoredWearablesState
 
-    private val _removeState: MutableLiveData<RemoveState> = SingleLiveEvent()
-    val removeState: LiveData<RemoveState> = _removeState
+    private val _removeSingleWearableState = SingleLiveEvent<RemoveSingleWearableState>()
+    val removeSingleWearableState: LiveData<RemoveSingleWearableState>
+        get() = _removeSingleWearableState
 
-    private val _removeAllState: MutableLiveData<RemoveAllState> = SingleLiveEvent()
-    val removeAllState: LiveData<RemoveAllState> = _removeAllState
+    private val _removeAllWearablesState = SingleLiveEvent<RemoveAllWearablesState>()
+    val removeAllWearablesState: LiveData<RemoveAllWearablesState>
+        get() = _removeAllWearablesState
+
+    private lateinit var wearableToRemove: WearablesManager.Wearable
+    private var getStoredWearablesJob: Job? = null
 
     init {
         fetchWearables()
     }
 
-    private suspend fun getStoredWearablesAsync() =
+    private suspend fun getAllWearables() =
         suspendCancellableCoroutine<List<WearablesManager.Wearable>> { continuation ->
             wearablesManager.getStoredWearables(object :
                 WearablesManager.GetStoredWearablesCallback {
@@ -49,89 +52,158 @@ class WearablesSettingsViewModel(
             }).disposeWhenCancelled(continuation)
         }
 
-    fun fetchWearables() = viewModelScope.launch(defaultDispatcher) {
-        try {
-            _getStoredWearablesState.postValue(
-                GetStoredWearablesState.Success(
-                    getStoredWearablesAsync().map { WearableItem(it, nowProvider.now) })
-            )
-        } catch (exception: Exception) {
-            _getStoredWearablesState.postValue(GetStoredWearablesState.Failure(exception))
+    fun fetchWearables() {
+        getStoredWearablesJob?.let {
+            if (it.isActive) {
+                return
+            }
+        }
+
+        getStoredWearablesJob = viewModelScope.launch(defaultDispatcher) {
+            _getStoredWearablesState.postValue(GetStoredWearablesState.GettingStoredWearables)
+            try {
+                val wearables = getAllWearables().map {
+                    WearableItem(it, nowProvider.now)
+                }
+                _getStoredWearablesState.postValue(
+                    GetStoredWearablesState.GotStoredWearables(wearables)
+                )
+            } catch (e: Exception) {
+                _getStoredWearablesState.postValue(GetStoredWearablesState.Failed(e))
+            }
         }
     }
 
-    fun cancelRemoveWearable(wearable: WearablesManager.Wearable) =
-        viewModelScope.launch(defaultDispatcher) {
-            wearablesManager.cancelRemoveWearable(
-                wearable,
+    fun requestNewWearable() {
+        _newWearableState.postValue(NewWearableState.AddingNewWearable)
+    }
+
+    fun addedNewWearable() {
+        if (_newWearableState.value!! !is NewWearableState.AddedNewWearable) {
+            _newWearableState.postValue(NewWearableState.AddedNewWearable)
+        }
+    }
+
+    private fun removeWearable(wearable: WearablesManager.Wearable) {
+        viewModelScope.launch {
+            try {
+                if (wearable.isPendingRemoval) {
+                    cancelRemoveWearable(wearable)
+                    _removeSingleWearableState.postValue(
+                        RemoveSingleWearableState.CancelledWearableRemoval(wearable)
+                    )
+                } else {
+                    removeSingleWearable(wearable)
+                    _removeSingleWearableState.postValue(
+                        RemoveSingleWearableState.PendingWearableRemoval(wearable)
+                    )
+                }
+                fetchWearables()
+            } catch (e: Exception) {
+                _removeSingleWearableState.postValue(RemoveSingleWearableState.Failed(e))
+            }
+        }
+    }
+
+    fun removeSelectedWearable() {
+        removeWearable(wearableToRemove)
+    }
+
+    fun setWearableToRemove(wearable: WearablesManager.Wearable) {
+        wearableToRemove = wearable
+        _removeSingleWearableState.postValue(
+            RemoveSingleWearableState.RemovingWearable(wearable)
+        )
+    }
+
+    private suspend fun removeSingleWearable(wearable: WearablesManager.Wearable) =
+        suspendCancellableCoroutine<Exception?> { continuation ->
+            wearablesManager.removeWearable(wearable,
+                object : WearablesManager.RemoveWearableCallback {
+                    override fun onRemoveSuccess() {
+                        continuation.resume(null)
+                    }
+
+                    override fun onRemoveFailure(e: Exception) {
+                        continuation.resumeWithException(e)
+                    }
+                }).disposeWhenCancelled(continuation)
+        }
+
+    private suspend fun cancelRemoveWearable(wearable: WearablesManager.Wearable) =
+        suspendCancellableCoroutine<Exception?> { continuation ->
+            wearablesManager.cancelRemoveWearable(wearable,
                 object : WearablesManager.CancelRemoveWearableCallback {
                     override fun onCancelRemoveSuccess() {
-                        _cancelRemoveState.postValue(
-                            CancelRemoveState.Success(
-                                WearableItem(
-                                    wearable,
-                                    nowProvider.now
-                                )
-                            )
-                        )
-                        fetchWearables()
+                        continuation.resume(null)
                     }
 
                     override fun onCancelRemoveFailure(e: Exception) {
-                        _cancelRemoveState.postValue(CancelRemoveState.Failure(e))
+                        continuation.resumeWithException(e)
                     }
                 })
         }
 
-    fun removeWearable(wearable: WearablesManager.Wearable) {
-        wearablesManager.removeWearable(wearable, object : WearablesManager.RemoveWearableCallback {
-            override fun onRemoveSuccess() {
-                _removeState.postValue(RemoveState.Success(WearableItem(wearable, nowProvider.now)))
-                fetchWearables()
-            }
-
-            override fun onRemoveFailure(e: Exception) {
-                _removeState.postValue(RemoveState.Failure(e))
-            }
-        })
+    fun requestRemoveAllWearables() {
+        _removeAllWearablesState.postValue(RemoveAllWearablesState.RemovingAllWearables)
     }
 
-    fun removeAllWearables() = viewModelScope.launch(defaultDispatcher) {
-        try {
-            getStoredWearablesAsync().forEach {
-                try {
-                    if (!it.isPendingRemoval) {
-                        removeWearable(it)
+    fun removeAllWearables() {
+        viewModelScope.launch(defaultDispatcher) {
+            val wearables: List<WearablesManager.Wearable>
+            try {
+                wearables = getAllWearables()
+            } catch (exception: Exception) {
+                _removeAllWearablesState.postValue(RemoveAllWearablesState.Failed(exception))
+                return@launch
+            }
+
+            launch {
+                wearables.forEach { wearable ->
+                    try {
+                        if (!wearable.isPendingRemoval) {
+                            removeSingleWearable(wearable)
+                        }
+                    } catch (e: Exception) {
+                        _removeAllWearablesState.postValue(RemoveAllWearablesState.Failed(e))
+                        cancel()
                     }
-                } catch (exception: Exception) {
-                    _removeAllState.postValue(RemoveAllState.Failure(exception))
-                    cancel()
-                    return@launch
+                }
+            }.invokeOnCompletion {
+                if (it == null) {
+                    _removeAllWearablesState.postValue(RemoveAllWearablesState.PendingRemovalForAllWearables)
                 }
             }
-            _removeAllState.postValue(RemoveAllState.Success())
-        } catch (exception: Exception) {
-            _removeAllState.postValue(RemoveAllState.Failure(exception))
         }
     }
 
     sealed class GetStoredWearablesState {
-        data class Success(val wearables: List<WearableItem>) : GetStoredWearablesState()
-        data class Failure(val exception: Exception) : GetStoredWearablesState()
+        object GettingStoredWearables : GetStoredWearablesState()
+        data class GotStoredWearables(val wearables: List<WearableItem>) : GetStoredWearablesState()
+        data class Failed(val failure: Exception) : GetStoredWearablesState()
     }
 
-    sealed class RemoveState {
-        data class Success(val wearable: WearableItem) : RemoveState()
-        data class Failure(val exception: Exception) : RemoveState()
+    sealed class RemoveAllWearablesState {
+        object RemovingAllWearables : RemoveAllWearablesState()
+        object PendingRemovalForAllWearables : RemoveAllWearablesState()
+        data class Failed(val failure: Exception) : RemoveAllWearablesState()
     }
 
-    sealed class CancelRemoveState {
-        data class Success(val wearable: WearableItem) : CancelRemoveState()
-        data class Failure(val exception: Exception) : CancelRemoveState()
+    sealed class RemoveSingleWearableState {
+        data class RemovingWearable(val wearable: WearablesManager.Wearable) :
+            RemoveSingleWearableState()
+
+        data class PendingWearableRemoval(val wearable: WearablesManager.Wearable) :
+            RemoveSingleWearableState()
+
+        data class CancelledWearableRemoval(val wearable: WearablesManager.Wearable) :
+            RemoveSingleWearableState()
+
+        data class Failed(val exception: Exception) : RemoveSingleWearableState()
     }
 
-    sealed class RemoveAllState {
-        class Success : RemoveAllState()
-        data class Failure(val exception: Exception) : RemoveAllState()
+    sealed class NewWearableState {
+        object AddingNewWearable : NewWearableState()
+        object AddedNewWearable : NewWearableState()
     }
 }


### PR DESCRIPTION
- Using coroutines instead of executors
- Class and logic is now similar to LocationsSetting screen & viewmodels

> **Note: Locations/Wearables Main/Add/Settings fragments & viewmodels can be abstracted and be made generic to allow for code reuse instead of duplicating**