### PR TITLE
Refactor Wearables and Fix dialogs

### DIFF
--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/DiscoveredWearablesAdapter.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/DiscoveredWearablesAdapter.kt
@@ -1,0 +1,58 @@
+package com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.launchkey.android.authenticator.sdk.core.auth_method_management.WearablesManager
+import com.launchkey.android.authenticator.sdk.ui.AuthenticatorUIManager
+import com.launchkey.android.authenticator.sdk.ui.databinding.ItemBluetoothDeviceDiscoverBinding
+
+class DiscoveredWearablesAdapter(
+    private val onItemClickListener: ((WearablesManager.Wearable) -> Unit)
+) : ListAdapter<WearablesManager.Wearable, DiscoveredWearablesAdapter.ViewHolder>(DIFF_CALLBACK) {
+
+    private companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<WearablesManager.Wearable>() {
+            override fun areItemsTheSame(
+                oldItem: WearablesManager.Wearable,
+                newItem: WearablesManager.Wearable
+            ): Boolean = oldItem.id == newItem.id
+
+            override fun areContentsTheSame(
+                oldItem: WearablesManager.Wearable,
+                newItem: WearablesManager.Wearable
+            ): Boolean = oldItem.name == newItem.name &&
+                    oldItem.isActive == newItem.isActive &&
+                    oldItem.isPendingRemoval == newItem.isPendingRemoval &&
+                    oldItem.timeRemainingUntilActivated == newItem.timeRemainingUntilActivated &&
+                    oldItem.timeRemainingUntilRemoved == newItem.timeRemainingUntilRemoved
+
+        }
+    }
+
+    class ViewHolder(val binding: ItemBluetoothDeviceDiscoverBinding) :
+        RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            ItemBluetoothDeviceDiscoverBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            ).apply {
+                val listItemsUiProp =
+                    AuthenticatorUIManager.instance.config.themeObj().listItems
+                root.background = listItemsUiProp.colorBg
+                bluetoothTextTitle.setTextColor(listItemsUiProp.colorText)
+            })
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = currentList[position]
+        val label = if (item.name.isBlank()) item.id else item.name
+        holder.binding.bluetoothTextTitle.text = label
+        holder.binding.root.setOnClickListener { onItemClickListener(currentList[position]) }
+    }
+}

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesAddFragment.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesAddFragment.kt
@@ -8,199 +8,92 @@ import android.bluetooth.BluetoothAdapter
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
-import android.view.*
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import com.launchkey.android.authenticator.sdk.core.auth_method_management.WearablesManager
 import com.launchkey.android.authenticator.sdk.core.auth_method_management.exception.wearables.BluetoothDisabledException
 import com.launchkey.android.authenticator.sdk.core.auth_method_management.exception.wearables.BluetoothPermissionException
 import com.launchkey.android.authenticator.sdk.core.auth_method_management.exception.wearables.WearableWithSameNameExistsException
-import com.launchkey.android.authenticator.sdk.ui.AuthenticatorUIManager
 import com.launchkey.android.authenticator.sdk.ui.R
 import com.launchkey.android.authenticator.sdk.ui.databinding.FragmentWearablesAddBinding
-import com.launchkey.android.authenticator.sdk.ui.databinding.ItemBluetoothDeviceDiscoverBinding
 import com.launchkey.android.authenticator.sdk.ui.internal.common.Constants
-import com.launchkey.android.authenticator.sdk.ui.internal.dialog.*
+import com.launchkey.android.authenticator.sdk.ui.internal.dialog.AlertDialogFragment
+import com.launchkey.android.authenticator.sdk.ui.internal.dialog.GenericAlertDialogFragment
+import com.launchkey.android.authenticator.sdk.ui.internal.dialog.HelpDialogFragment
+import com.launchkey.android.authenticator.sdk.ui.internal.dialog.SetNameDialogFragment
 import com.launchkey.android.authenticator.sdk.ui.internal.util.*
-import java.util.*
 
-class WearablesAddFragment : BaseAppCompatFragment(R.layout.fragment_wearables_add), OnRefreshListener {
+class WearablesAddFragment : BaseAppCompatFragment(R.layout.fragment_wearables_add) {
     companion object {
-        private const val BT_DISABLED_ALERT_RESULT = "BT_DISABLED_ALERT_RESULT"
-        private const val BT_DISABLED_ALERT = "BT_DISABLED_ALERT"
+        private const val DIALOG_BLUETOOTH_DISABLED = "BT_DISABLED_ALERT"
+        private const val DIALOG_SET_NAME = "SET_NAME"
     }
 
     private val binding: FragmentWearablesAddBinding by viewBinding(FragmentWearablesAddBinding::bind)
     private val wearablesAddViewModel: WearablesAddViewModel by viewModels({ requireParentFragment() })
-    private val devicesDisplayed: MutableList<WearablesManager.Wearable> = mutableListOf()
-    private val devicesWithNames: MutableList<WearablesManager.Wearable> = mutableListOf()
-    private val devicesWithoutNames: MutableList<WearablesManager.Wearable> = mutableListOf()
-    private var selectedItem: WearablesManager.Wearable? = null
-    private var bluetoothOffNotified = false
-    private val btLauncher = registerForActivityResult(StartActivityForResult(), ActivityResultCallback { result ->
-        if (result == null) return@ActivityResultCallback
-        if (result.resultCode == Activity.RESULT_OK) {
-            onRefresh()
-        } else {
-            bluetoothDisabledAlertDialog.changeState(DialogFragmentViewModel.State.NeedsToBeShown)
-        }
-    })
-    private lateinit var bluetoothDisabledAlertDialog: DialogFragmentViewModel
-    private lateinit var bluetoothDisabledResultAlertDialog: DialogFragmentViewModel
-    private lateinit var setNameAlertDialog: DialogFragmentViewModel
-    private val okClick = DialogInterface.OnClickListener { _, _ ->
-        val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
-        btLauncher.launch(enableBtIntent)
+    private val wearablesScanViewModel: WearablesScanViewModel by viewModels()
+
+    private val enabledBluetoothLauncher =
+        registerForActivityResult(StartActivityForResult(), ActivityResultCallback { result ->
+            if (result == null) return@ActivityResultCallback
+            if (result.resultCode == Activity.RESULT_OK) {
+                scanWearables()
+            } else {
+                requireActivity().onBackPressed()
+            }
+        })
+
+    private val setNameDialogFragment: SetNameDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(DIALOG_SET_NAME) as? SetNameDialogFragment
+
+    private val setNameDialogDone = SetNameDialogFragment.SetNameListener { _, name ->
+        wearablesAddViewModel.addSelectedWearableWithName(name!!)
     }
-    private val cancelListener = DialogInterface.OnCancelListener { requireActivity().onBackPressed() }
-    private val okClickResult = DialogInterface.OnClickListener { dialog, which -> cancelListener.onCancel(dialog) }
-    private val cancelListenerResult = DialogInterface.OnCancelListener { requireActivity().onBackPressed() }
+
+    private val setNameDialogCancel = DialogInterface.OnCancelListener {
+        wearablesAddViewModel.cancelNaming()
+    }
+
+    private val discoveredWearablesAdapter: DiscoveredWearablesAdapter
+        get() = binding.wearablesAddRecyclerview.adapter as DiscoveredWearablesAdapter
+
+    private val bluetoothDisabledDialogFragment: AlertDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(DIALOG_BLUETOOTH_DISABLED) as? AlertDialogFragment
+
+    private val bluetoothDialogOk = DialogInterface.OnClickListener { _, _ ->
+        requestBluetoothEnabling()
+    }
+
+    private val bluetoothDialogCancel = DialogInterface.OnCancelListener {
+        requireActivity().onBackPressed()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.proximityAddSwiperefresh.setOnRefreshListener(this)
-        binding.proximityAddSwiperefresh.isRefreshing = true
-        binding.proximityAddSwiperefresh.setColorSchemeColors(
-                UiUtils.getColorFromTheme(requireContext(), R.attr.authenticatorColorAccent, R.color.lk_wl_default_accent))
-        bluetoothDisabledAlertDialog = ViewModelProvider(this, defaultViewModelProviderFactory).get(BT_DISABLED_ALERT_RESULT, DialogFragmentViewModel::class.java)
-        bluetoothDisabledResultAlertDialog = ViewModelProvider(this, defaultViewModelProviderFactory).get(BT_DISABLED_ALERT, DialogFragmentViewModel::class.java)
-        setNameAlertDialog = ViewModelProvider(this, defaultViewModelProviderFactory).get(SetNameDialogFragment::class.java.simpleName, DialogFragmentViewModel::class.java)
-        val toggle = binding.proximityAddFilterSwitch
-        toggle.setOnCheckedChangeListener { _, isChecked -> updateDevicesDisplayed(isChecked) }
-        val toggleLayout: View = binding.proximityAddFilterLayout
-        toggleLayout.setOnClickListener { toggle.isChecked = !toggle.isChecked }
-        val adapter = DiscoveredWearablesAdapter(devicesDisplayed) { onItemSelect(it) }
-        val recyclerView = binding.wearablesAddRecyclerview
-        recyclerView.adapter = adapter
-        recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.setHasFixedSize(true)
-        if (!wearablesAddViewModel.isSupported()) {
-            requireActivity().onBackPressed()
-        }
-        bluetoothDisabledAlertDialog.state.observe(viewLifecycleOwner) { state ->
-            if (state is DialogFragmentViewModel.State.NeedsToBeShown) {
-                GenericAlertDialogFragment.show(childFragmentManager,
-                        this@WearablesAddFragment.requireContext(),
-                        getString(R.string.ioa_generic_warning),
-                        getString(R.string.ioa_sec_bp_add_error_bluetoothdisabled_message),
-                        null,
-                        true,
-                        null,
-                        BT_DISABLED_ALERT)
-                bluetoothDisabledAlertDialog.changeState(DialogFragmentViewModel.State.Shown)
-            } else if (state is DialogFragmentViewModel.State.Shown) {
-                val bluetoothDisabledDialog = childFragmentManager.findFragmentByTag(BT_DISABLED_ALERT) as AlertDialogFragment
-                bluetoothDisabledDialog.setPositiveButtonClickListener(okClickResult)
-                bluetoothDisabledDialog.setCancelListener(cancelListenerResult)
-            }
-        }
-        bluetoothDisabledResultAlertDialog.state.observe(viewLifecycleOwner) { state ->
-            if (state is DialogFragmentViewModel.State.NeedsToBeShown) {
-                GenericAlertDialogFragment.show(childFragmentManager,
-                        this@WearablesAddFragment.requireContext(),
-                        getString(R.string.ioa_sec_bp_add_error_bluetoothdisabled_title),
-                        getString(R.string.ioa_sec_bp_add_error_bluetoothdisabled_message),
-                        null,
-                        true,
-                        null,
-                        BT_DISABLED_ALERT_RESULT)
-                bluetoothDisabledResultAlertDialog.changeState(DialogFragmentViewModel.State.Shown)
-            } else if (state is DialogFragmentViewModel.State.Shown) {
-                val bluetoothDisabledDialog = childFragmentManager.findFragmentByTag(BT_DISABLED_ALERT_RESULT) as AlertDialogFragment
-                bluetoothDisabledDialog.setPositiveButtonClickListener(okClick)
-                bluetoothDisabledDialog.setCancelListener(cancelListener)
-            }
-        }
-        setNameAlertDialog.state.observe(viewLifecycleOwner) { state ->
-            if (state is DialogFragmentViewModel.State.NeedsToBeShown) {
-                SetNameDialogFragment.show(
-                        requireContext(),
-                        childFragmentManager,
-                        R.string.ioa_sec_bp_add_dialog_setname_title,
-                        R.string.ioa_sec_bp_add_dialog_setname_hint,
-                        R.string.ioa_generic_done,
-                        selectedItem!!.name)
-                setNameAlertDialog.changeState(DialogFragmentViewModel.State.Shown)
-            } else if (state is DialogFragmentViewModel.State.Shown) {
-                val setNameDialogFragment = childFragmentManager.findFragmentByTag(SetNameDialogFragment::class.java.simpleName) as SetNameDialogFragment
-                setNameDialogFragment.setPositiveButtonClickListener(object : SetNameDialogFragment.SetNameListener {
-                    override fun onNameSet(dialog: SetNameDialogFragment?, name: String?) {
-                        selectedItem!!.name = name!!
-                        wearablesAddViewModel.addWearable(selectedItem!!)
-                    }
-                })
-            }
-        }
 
-        wearablesAddViewModel.availableWearablesState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesAddViewModel.AvailableWearablesState.AvailableWearablesSuccess -> {
-                    val nameFilter = { withName: Boolean ->
-                        filter@{ wearable: WearablesManager.Wearable -> Boolean
-                            val s = wearable.name.trim { it <= ' ' }
-                            return@filter if (withName) s.isNotEmpty() else s.isEmpty()
-                        }
-                    }
-                    devicesWithNames.clear()
-                    devicesWithNames.addAll(it.wearables.filter(nameFilter(true)))
-                    devicesWithoutNames.clear()
-                    devicesWithoutNames.addAll(it.wearables.filter(nameFilter(false)))
-                    updateDevicesDisplayed(binding.proximityAddFilterSwitch.isChecked)
-                }
-                is WearablesAddViewModel.AvailableWearablesState.FailedToGetAvailableWearables -> {
-                    val emptyView = binding.proximityAddEmpty
-                    emptyView.makeVisible()
-                    emptyView.setText(R.string.ioa_sec_bp_add_empty)
-                    if (it.exception is BluetoothDisabledException ||
-                            it.exception is BluetoothPermissionException) {
-                        requestBluetoothEnabling()
-                    } else {
-                        // Exit
-                        requireActivity().onBackPressed()
-                    }
-                }
-            }
-        }
-        wearablesAddViewModel.addWearableState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesAddViewModel.AddWearableState.AddedNewWearable -> {
-                    val setNameDialogFragment = childFragmentManager.findFragmentByTag(SetNameDialogFragment::class.java.simpleName) as SetNameDialogFragment
-                    setNameDialogFragment.dismiss()
-                    (requireParentFragment() as WearablesFragment).wearableAdded = true
-                    requireActivity().onBackPressed()
-                }
-                is WearablesAddViewModel.AddWearableState.FailedToAddWearable -> {
-                    val errorMessage = getErrorMessage(it.failure)
-                    val setNameDialogFragment = childFragmentManager.findFragmentByTag(SetNameDialogFragment::class.java.simpleName) as SetNameDialogFragment
-                    setNameDialogFragment.setErrorMessage(errorMessage)
-                }
-            }
-        }
+        bluetoothDisabledDialogFragment?.setPositiveButtonClickListener(bluetoothDialogOk)
+        bluetoothDisabledDialogFragment?.setCancelListener(bluetoothDialogCancel)
+
+        setNameDialogFragment?.setPositiveButtonClickListener(setNameDialogDone)
+        setNameDialogFragment?.setCancelListener(setNameDialogCancel)
+
+        setupRefresh()
+        setupToggle()
+        setupWearablesList()
+        subscribeObservers()
     }
 
-    private fun getErrorMessage(exception: Exception): String? {
-        if (exception is WearablesAddViewModel.WearableNameTooShortException) {
-            return resources.getQuantityString(
-                    R.plurals.ioa_sec_bp_add_error_invalidname_message_format, Constants.MINIMUM_INPUT_LENGTH, Constants.MINIMUM_INPUT_LENGTH)
-        }
-
-        return if (exception is WearableWithSameNameExistsException) {
-            getString(R.string.ioa_sec_bp_add_error_usedname_message)
-        } else {
-            getString(R.string.ioa_error_unknown_format, exception.message)
-        }
-    }
-    
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         UiUtils.applyThemeToMenu(inflater, menu)
     }
@@ -208,73 +101,173 @@ class WearablesAddFragment : BaseAppCompatFragment(R.layout.fragment_wearables_a
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         val id = item.itemId
         if (id == R.id.action_help) {
-            HelpDialogFragment.show(childFragmentManager, requireContext(), getString(R.string.ioa_sec_bp_help_title), getString(R.string.ioa_sec_bp_help_message))
+            HelpDialogFragment.show(
+                childFragmentManager,
+                requireContext(),
+                getString(R.string.ioa_sec_bp_help_title),
+                getString(R.string.ioa_sec_bp_help_message)
+            )
             return true
         }
         return super.onOptionsItemSelected(item)
     }
 
-    private fun updateDevicesDisplayed(toggle: Boolean) {
-        devicesDisplayed.clear()
-        devicesDisplayed.addAll(devicesWithNames)
-        if (toggle) {
-            devicesDisplayed.addAll(devicesWithoutNames)
-        }
-        binding.wearablesAddRecyclerview.adapter!!.notifyDataSetChanged()
-
-        binding.proximityAddEmpty.setText(R.string.ioa_sec_bp_add_empty)
-        val emptyView = binding.proximityAddEmpty
-        binding.proximityAddSwiperefresh.isRefreshing = false
-        if (devicesDisplayed.isEmpty()) {
-            emptyView.makeVisible()
-        } else {
-            emptyView.makeInvisible()
+    private fun setupRefresh() {
+        with(binding.proximityAddSwiperefresh) {
+            setOnRefreshListener { scanWearables() }
+            isRefreshing = true
+            setColorSchemeColors(
+                UiUtils.getColorFromTheme(
+                    requireContext(),
+                    R.attr.authenticatorColorAccent,
+                    R.color.lk_wl_default_accent
+                )
+            )
         }
     }
 
-    override fun onRefresh() {
-        devicesWithNames.clear()
-        devicesWithoutNames.clear()
-        devicesDisplayed.clear()
-        binding.wearablesAddRecyclerview.adapter!!.notifyDataSetChanged()
-        binding.proximityAddEmpty.setText(R.string.ioa_sec_bp_add_searching)
-        wearablesAddViewModel.getAvailableWearables()
+    private fun setupToggle() {
+        val includeUnnamedDevicesToggle = binding.proximityAddFilterSwitch
+        includeUnnamedDevicesToggle.setOnCheckedChangeListener { _, isChecked ->
+            val scanState =
+                (wearablesScanViewModel.scanState.value as WearablesScanViewModel.WearablesScanState.FoundAvailableWearables)
+
+            discoveredWearablesAdapter.submitList(
+                if (isChecked) scanState.wearablesWithNames + scanState.wearablesWithoutNames
+                else scanState.wearablesWithNames
+            )
+        }
+        binding.proximityAddFilterLayout.setOnClickListener {
+            includeUnnamedDevicesToggle.isChecked = !includeUnnamedDevicesToggle.isChecked
+        }
+    }
+
+    private fun setupWearablesList() {
+        with(binding.wearablesAddRecyclerview) {
+            adapter = DiscoveredWearablesAdapter { wearablesAddViewModel.startNamingWearable(it) }
+            layoutManager = LinearLayoutManager(requireContext())
+            setHasFixedSize(true)
+        }
+    }
+
+    private fun subscribeObservers() {
+        wearablesScanViewModel.scanState.observe(viewLifecycleOwner) { scanState ->
+            when (scanState) {
+                WearablesScanViewModel.WearablesScanState.Scanning -> {
+                    binding.proximityAddSwiperefresh.isRefreshing = true
+                    binding.proximityAddEmpty.setText(R.string.ioa_sec_bp_add_searching)
+                }
+                is WearablesScanViewModel.WearablesScanState.FoundAvailableWearables -> {
+                    binding.proximityAddSwiperefresh.isRefreshing = false
+                    updateDevicesDisplayed(
+                        scanState.wearablesWithNames,
+                        scanState.wearablesWithoutNames,
+                        binding.proximityAddFilterSwitch.isChecked
+                    )
+                }
+                is WearablesScanViewModel.WearablesScanState.FailedToGetAvailableWearables -> {
+                    binding.proximityAddSwiperefresh.isRefreshing = false
+                    val emptyView = binding.proximityAddEmpty
+                    emptyView.makeVisible()
+                    emptyView.setText(R.string.ioa_sec_bp_add_empty)
+                    when (scanState.failure) {
+                        // TODO: 10/18/21 BluetoothPermissionException might need a separate case?
+                        is BluetoothDisabledException, is BluetoothPermissionException -> {
+                            showBluetoothDisabledDialog()
+                        }
+                        else -> requireActivity().onBackPressed() // exit
+                    }
+                }
+            }
+        }
+
+        wearablesAddViewModel.addWearableState.observe(viewLifecycleOwner) {
+            when (it) {
+                is WearablesAddViewModel.AddWearableState.SelectingWearable -> {
+                }
+                is WearablesAddViewModel.AddWearableState.NamingWearable -> {
+                    showSetNameDialog(it.wearable)
+                }
+                is WearablesAddViewModel.AddWearableState.AddedNewWearable -> {
+                    setNameDialogFragment?.dismiss()
+                }
+                is WearablesAddViewModel.AddWearableState.FailedToAddWearable -> {
+                    setNameDialogFragment?.setErrorMessage(getErrorMessage(it.failure))
+                }
+            }
+        }
+    }
+
+    private fun getErrorMessage(exception: Exception): String = when (exception) {
+        is WearablesAddViewModel.WearableNameTooShortException -> {
+            resources.getQuantityString(
+                R.plurals.ioa_sec_bp_add_error_invalidname_message_format,
+                Constants.MINIMUM_INPUT_LENGTH,
+                Constants.MINIMUM_INPUT_LENGTH
+            )
+        }
+        is WearableWithSameNameExistsException -> {
+            getString(R.string.ioa_sec_bp_add_error_usedname_message)
+        }
+        else -> {
+            getString(R.string.ioa_error_unknown_format, exception.message)
+        }
+    }
+
+    private fun updateDevicesDisplayed(
+        wearablesWithNames: List<WearablesManager.Wearable>,
+        wearablesWithoutNames: List<WearablesManager.Wearable>,
+        includeWearablesWithoutNames: Boolean
+    ) {
+        val wearables =
+            if (includeWearablesWithoutNames) wearablesWithNames + wearablesWithoutNames
+            else wearablesWithNames
+
+        discoveredWearablesAdapter.submitList(wearables)
+        binding.proximityAddEmpty.setText(R.string.ioa_sec_bp_add_empty)
+        if (wearables.isEmpty()) binding.proximityAddEmpty.makeVisible()
+        else binding.proximityAddEmpty.makeInvisible()
+    }
+
+    private fun scanWearables() {
+        wearablesScanViewModel.scanForAvailableWearables()
+    }
+
+    private fun showBluetoothDisabledDialog() {
+        if (bluetoothDisabledDialogFragment != null) return
+
+        GenericAlertDialogFragment.show(
+            childFragmentManager,
+            requireContext(),
+            getString(R.string.ioa_sec_bp_add_error_bluetoothdisabled_title),
+            getString(R.string.ioa_sec_bp_add_error_bluetoothdisabled_message),
+            null,
+            true,
+            null,
+            DIALOG_BLUETOOTH_DISABLED
+        ).also {
+            it.setPositiveButtonClickListener(bluetoothDialogOk)
+            it.setCancelListener(bluetoothDialogCancel)
+        }
+    }
+
+    private fun showSetNameDialog(wearable: WearablesManager.Wearable) {
+        SetNameDialogFragment.show(
+            requireContext(),
+            childFragmentManager,
+            R.string.ioa_sec_bp_add_dialog_setname_title,
+            R.string.ioa_sec_bp_add_dialog_setname_hint,
+            R.string.ioa_generic_done,
+            wearable.name,
+            DIALOG_SET_NAME
+        ).also {
+            it.setPositiveButtonClickListener(setNameDialogDone)
+            it.setCancelListener(setNameDialogCancel)
+        }
     }
 
     private fun requestBluetoothEnabling() {
-        if (bluetoothOffNotified) {
-            return
-        }
-        bluetoothOffNotified = true
-        bluetoothDisabledResultAlertDialog.changeState(DialogFragmentViewModel.State.NeedsToBeShown)
-    }
-
-    private fun onItemSelect(genericDevice: WearablesManager.Wearable) {
-        selectedItem = genericDevice
-        setNameAlertDialog.changeState(DialogFragmentViewModel.State.NeedsToBeShown)
-    }
-
-    private class DiscoveredWearablesAdapter(
-            private val devices: List<WearablesManager.Wearable>,
-            private val onItemClickListener: ((WearablesManager.Wearable) -> Unit)
-            ) : RecyclerView.Adapter<DiscoveredWearablesAdapter.ViewHolder>() {
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-            return ViewHolder(ItemBluetoothDeviceDiscoverBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
-                val listItemsUiProp = AuthenticatorUIManager.instance.config.themeObj().listItems
-                root.background = listItemsUiProp.colorBg
-                bluetoothTextTitle.setTextColor(listItemsUiProp.colorText)
-            })
-        }
-
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val item = devices[position]
-            val label = if (item.name.trim { it <= ' ' }.isEmpty()) item.id else item.name
-            holder.binding.bluetoothTextTitle.text = label
-            holder.binding.root.setOnClickListener { onItemClickListener(devices[position]) }
-        }
-
-        override fun getItemCount(): Int = devices.size
-
-        private class ViewHolder(val binding: ItemBluetoothDeviceDiscoverBinding) : RecyclerView.ViewHolder(binding.root)
+        val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
+        enabledBluetoothLauncher.launch(enableBtIntent)
     }
 }

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesScanViewModel.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesScanViewModel.kt
@@ -1,0 +1,70 @@
+package com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.launchkey.android.authenticator.sdk.core.auth_method_management.WearablesManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class WearablesScanViewModel(
+    private val wearablesManager: WearablesManager,
+    private val defaultDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    init {
+        scanForAvailableWearables()
+    }
+
+    private val _scanState = MutableLiveData<WearablesScanState>(WearablesScanState.Scanning)
+
+    val scanState: LiveData<WearablesScanState>
+        get() = _scanState
+
+    fun scanForAvailableWearables() {
+        viewModelScope.launch(defaultDispatcher) {
+            _scanState.postValue(WearablesScanState.Scanning)
+            try {
+                val (wearablesWithNames, wearablesWithoutNames) =
+                    getAvailableWearables().partition { wearable -> wearable.name.isNotBlank() }
+                _scanState.postValue(
+                    WearablesScanState.FoundAvailableWearables(
+                        wearablesWithNames,
+                        wearablesWithoutNames
+                    )
+                )
+            } catch (e: java.lang.Exception) {
+                _scanState.postValue(WearablesScanState.FailedToGetAvailableWearables(e))
+            }
+        }
+    }
+
+    private suspend fun getAvailableWearables() =
+        suspendCancellableCoroutine<List<WearablesManager.Wearable>> { continuation ->
+            wearablesManager.getAvailableWearables(object :
+                WearablesManager.GetAvailableWearablesCallback {
+                override fun onGetSuccess(wearables: MutableList<WearablesManager.Wearable>) {
+                    continuation.resume(wearables)
+                }
+
+                override fun onGetFailure(exception: java.lang.Exception) {
+                    continuation.resumeWithException(exception)
+                }
+            })
+        }
+
+    sealed class WearablesScanState {
+        object Scanning : WearablesScanState()
+
+        data class FoundAvailableWearables(
+            val wearablesWithNames: List<WearablesManager.Wearable>,
+            val wearablesWithoutNames: List<WearablesManager.Wearable>
+        ) : WearablesScanState()
+
+        data class FailedToGetAvailableWearables(val failure: Exception) : WearablesScanState()
+    }
+}

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsFragment.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsFragment.kt
@@ -3,9 +3,11 @@
  */
 package com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables
 
-import android.content.DialogInterface
 import android.os.Bundle
-import android.view.*
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -15,14 +17,16 @@ import com.launchkey.android.authenticator.sdk.ui.AuthenticatorUIManager
 import com.launchkey.android.authenticator.sdk.ui.R
 import com.launchkey.android.authenticator.sdk.ui.databinding.FragmentBluetoothSettingsBinding
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.ItemAdapter
+import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.SettingsPanel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.TimerViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.VerificationFlagViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.common.TimeAgo
 import com.launchkey.android.authenticator.sdk.ui.internal.dialog.AlertDialogFragment
-import com.launchkey.android.authenticator.sdk.ui.internal.dialog.DialogFragmentViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.dialog.GenericAlertDialogFragment
 import com.launchkey.android.authenticator.sdk.ui.internal.dialog.ProgressDialogFragment
-import com.launchkey.android.authenticator.sdk.ui.internal.util.*
+import com.launchkey.android.authenticator.sdk.ui.internal.util.BaseAppCompatFragment
+import com.launchkey.android.authenticator.sdk.ui.internal.util.UiUtils
+import com.launchkey.android.authenticator.sdk.ui.internal.util.viewBinding
 
 class WearablesSettingsFragment : BaseAppCompatFragment(R.layout.fragment_bluetooth_settings) {
     companion object {
@@ -30,212 +34,234 @@ class WearablesSettingsFragment : BaseAppCompatFragment(R.layout.fragment_blueto
         private const val REMOVE_SINGLE_TAG = "REMOVE_SINGLE_TAG"
     }
 
-    private val binding: FragmentBluetoothSettingsBinding by viewBinding(FragmentBluetoothSettingsBinding::bind)
-    private val wearablesSettingsViewModel: WearablesSettingsViewModel by viewModels({ requireParentFragment() })
-    private val verificationFlagViewModel: VerificationFlagViewModel by lazy { ViewModelProvider(this).get(VerificationFlagViewModel.WEARABLES, VerificationFlagViewModel::class.java) }
-    private val timerViewModel: TimerViewModel by viewModels()
-    private var loadingDialog: ProgressDialogFragment? = null
-    private val confirmRemoveDialog: AlertDialogFragment?
-        get() = childFragmentManager.findFragmentByTag(REMOVE_SINGLE_TAG) as? AlertDialogFragment
-    private val confirmRemoveSingleDialogViewModel: DialogFragmentViewModel by lazy { ViewModelProvider(this, defaultViewModelProviderFactory).get(REMOVE_SINGLE_TAG, DialogFragmentViewModel::class.java) }
-    private val confirmRemoveAllDialogViewModel: DialogFragmentViewModel by lazy { ViewModelProvider(this, defaultViewModelProviderFactory).get(REMOVE_ALL_TAG, DialogFragmentViewModel::class.java) }
-    private val yesClick = SingleRemoveDialogListener()
+    private lateinit var settingsPanel: SettingsPanel
+    private val binding by viewBinding(FragmentBluetoothSettingsBinding::bind)
     private val adapter: ItemAdapter<WearablesManager.Wearable>
         get() = binding.bluetoothSettingsList.adapter as ItemAdapter<WearablesManager.Wearable>
-
-    private inner class SingleRemoveDialogListener : DialogInterface.OnClickListener {
-        lateinit var wearable: WearablesManager.Wearable
-        override fun onClick(dialog: DialogInterface?, which: Int) {
-            if (confirmRemoveDialog == null) return
-            if (wearable.isPendingRemoval) {
-                wearablesSettingsViewModel.cancelRemoveWearable(wearable)
-            } else {
-                wearablesSettingsViewModel.removeWearable(wearable)
-            }
-        }
+    private val wearablesSettingsViewModel: WearablesSettingsViewModel by viewModels({ requireParentFragment() })
+    private val verificationFlagViewModel: VerificationFlagViewModel by lazy {
+        ViewModelProvider(this).get(
+            VerificationFlagViewModel.WEARABLES,
+            VerificationFlagViewModel::class.java
+        )
     }
+    private val timerViewModel: TimerViewModel by viewModels()
+
+    private val loadingDialogFragment: ProgressDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(ProgressDialogFragment::class.java.simpleName) as? ProgressDialogFragment
+    private val removeSingleWearableDialogFragment: AlertDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(REMOVE_SINGLE_TAG) as? AlertDialogFragment
+    private val removeAllWearablesDialogFragment: AlertDialogFragment?
+        get() = childFragmentManager.findFragmentByTag(REMOVE_ALL_TAG) as? AlertDialogFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState);
-        setHasOptionsMenu(true);
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.bluetooth_add, menu);
-        super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.bluetooth_add, menu)
+        super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.bluetooth_add -> {
+                wearablesSettingsViewModel.requestNewWearable()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val onRemoveAllListener = View.OnClickListener { confirmRemoveAllDialogViewModel.changeState(DialogFragmentViewModel.State.NeedsToBeShown) }
-        confirmRemoveAllDialogViewModel.state.observe(viewLifecycleOwner) { state ->
-            if (state is DialogFragmentViewModel.State.NeedsToBeShown) {
-                GenericAlertDialogFragment.show(childFragmentManager,
-                        requireContext(),
-                        getString(R.string.ioa_sec_bp_sett_dialog_remove_all_title),
-                        getString(R.string.ioa_sec_bp_sett_dialog_remove_all_messsage),
-                        getString(R.string.ioa_generic_yes),
-                        true,
-                        getString(R.string.ioa_generic_cancel),
-                        REMOVE_ALL_TAG)
-                confirmRemoveAllDialogViewModel.changeState(DialogFragmentViewModel.State.Shown)
-            } else if (state is DialogFragmentViewModel.State.Shown) {
-                val yesClick = DialogInterface.OnClickListener { dialog, which ->
-                    wearablesSettingsViewModel.removeAllWearables()
-                }
-                val removeAllDialog = childFragmentManager.findFragmentByTag(REMOVE_ALL_TAG) as AlertDialogFragment?
-                removeAllDialog!!.setPositiveButtonClickListener(yesClick)
+        setupSettingsPanel()
+        setupWearablesList()
+        subscribeObservers()
+
+        removeSingleWearableDialogFragment?.setPositiveButtonClickListener { _, _ ->
+            wearablesSettingsViewModel.removeSelectedWearable()
+        }
+        removeAllWearablesDialogFragment?.setPositiveButtonClickListener { _, _ ->
+            wearablesSettingsViewModel.removeAllWearables()
+        }
+    }
+
+    private fun setupSettingsPanel() {
+        settingsPanel = binding.bluetoothSettingsPanel.apply {
+            setRemoveText(R.string.ioa_sec_bp_sett_panel_remove_text)
+            setRemoveButtonText(R.string.ioa_sec_bp_sett_panel_remove_button)
+            setVerifiedWhenText(R.string.ioa_sec_panel_verify_always)
+            setOnRemoveButtonClick {
+                wearablesSettingsViewModel.requestRemoveAllWearables()
+            }
+            disallowSwitchSwipe()
+            setOnSwitchClickedListener {
+                verificationFlagViewModel.toggleVerificationFlag(
+                    if (isSwitchOn) VerificationFlag.State.ALWAYS
+                    else VerificationFlag.State.WHEN_REQUIRED
+                )
             }
         }
+    }
 
+    private fun setupWearablesList() {
         binding.bluetoothSettingsList.adapter = ItemAdapter<WearablesManager.Wearable>(
-                AuthenticatorUIManager.instance.config.themeObj(),
-                TimeAgo(requireContext()),
-                R.string.ioa_calabash_sett_remove_wear_item_format,
-                R.drawable.ic_bluetooth_black_24dp
+            AuthenticatorUIManager.instance.config.themeObj(),
+            TimeAgo(requireContext()),
+            R.string.ioa_calabash_sett_remove_wear_item_format,
+            R.drawable.ic_bluetooth_black_24dp
         ) { wearableToRemove ->
-            yesClick.wearable = wearableToRemove.item
-            confirmRemoveSingleDialogViewModel.changeState(DialogFragmentViewModel.State.NeedsToBeShown)
-
+            wearablesSettingsViewModel.setWearableToRemove(wearableToRemove.item)
         }
-        binding.bluetoothSettingsList.layoutManager = LinearLayoutManager(requireContext())
         binding.bluetoothSettingsList.setHasFixedSize(true)
-        confirmRemoveSingleDialogViewModel.state.observe(viewLifecycleOwner) { state ->
-            when (state) {
-                DialogFragmentViewModel.State.NeedsToBeShown -> {
-                    val item = yesClick.wearable
-                    val pendingRemoval = item.isPendingRemoval
-                    val name = item.name
-                    val header = if (pendingRemoval) getString(R.string.ioa_sec_bp_sett_dialog_undoremove_single_title) else getString(R.string.ioa_sec_bp_sett_dialog_remove_single_title)
-                    val message = if (pendingRemoval) getString(R.string.ioa_sec_bp_sett_dialog_undoremoval_message_format, name) else getString(R.string.ioa_sec_bp_sett_dialog_remove_single_message_format, name)
-                    GenericAlertDialogFragment.show(childFragmentManager,
-                            requireContext(),
-                            header,
-                            message,
-                            getString(R.string.ioa_generic_yes),
-                            true,
-                            getString(R.string.ioa_generic_cancel),
-                            REMOVE_SINGLE_TAG)
-                    confirmRemoveSingleDialogViewModel.changeState(DialogFragmentViewModel.State.Shown)
-                }
-                DialogFragmentViewModel.State.Shown -> {
-                    confirmRemoveDialog?.setPositiveButtonClickListener(yesClick)
-                }
-            }
-        }
-        loadingDialog = ProgressDialogFragment.newInstance(null, getString(R.string.ioa_sec_bp_sett_loading), false, true)
+        binding.bluetoothSettingsList.layoutManager = LinearLayoutManager(requireContext())
+    }
 
-        val settingsPanel = binding.bluetoothSettingsPanel
-
-        wearablesSettingsViewModel.getStoredWearablesState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesSettingsViewModel.GetStoredWearablesState.Success -> {
-                    timerViewModel.stopTimers()
-                    adapter.submitList(it.wearables)
-                    adapter.notifyDataSetChanged()
-                    loadingDialog!!.dismiss()
-                    val timerItems: List<TimerViewModel.TimerItem<WearableItem>> =
-                            it.wearables.mapNotNull { wearableItem ->
-                                when (wearableItem.pendingState) {
-                                    ItemAdapter.ItemPendingState.NotPending -> null
-                                    is ItemAdapter.ItemPendingState.PendingActivation -> TimerViewModel.TimerItem(
-                                            wearableItem,
-                                            (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingActivation).activatedAtTimeInMillis
-                                    )
-                                    is ItemAdapter.ItemPendingState.PendingRemoval -> TimerViewModel.TimerItem(
-                                            wearableItem,
-                                            (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingRemoval).removedAtTimeInMillis
-                                    )
-                                }
-                            }
-
-                    timerViewModel.startTimers(timerItems)
-                }
-                is WearablesSettingsViewModel.GetStoredWearablesState.Failure -> requireActivity().onBackPressed()
-            }
-        }
-
+    private fun subscribeObservers() {
         verificationFlagViewModel.verificationFlag.observe(viewLifecycleOwner) { verificationFlagState ->
             when (verificationFlagState) {
                 is VerificationFlagViewModel.VerificationFlagState.Failed -> requireActivity().finish()
                 VerificationFlagViewModel.VerificationFlagState.FetchingVerificationFlag -> Unit
                 is VerificationFlagViewModel.VerificationFlagState.Pending -> UiUtils.updateSettingsPanelWithFactorState(
-                        settingsPanel,
-                        verificationFlagState.verificationFlag,
-                        verificationFlagState.millisUntilToggled,
-                        false
+                    settingsPanel,
+                    verificationFlagState.verificationFlag,
+                    verificationFlagState.millisUntilToggled,
+                    false
                 )
                 is VerificationFlagViewModel.VerificationFlagState.GotVerificationFlag -> {
                     UiUtils.updateSettingsPanelWithFactorState(
-                            settingsPanel,
-                            verificationFlagState.verificationFlag,
-                            0,
-                            false
+                        settingsPanel,
+                        verificationFlagState.verificationFlag,
+                        0,
+                        false
                     )
                 }
             }
         }
 
-        wearablesSettingsViewModel.cancelRemoveState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesSettingsViewModel.CancelRemoveState.Success -> {
-                    timerViewModel.cancelTimerForItem(it.wearable)
+        wearablesSettingsViewModel.getStoredWearablesState.observe(viewLifecycleOwner) { fetchWearablesState ->
+            loadingDialogFragment?.dismiss()
+            when (fetchWearablesState) {
+                is WearablesSettingsViewModel.GetStoredWearablesState.GotStoredWearables -> {
+                    timerViewModel.stopTimers()
+                    adapter.submitList(fetchWearablesState.wearables)
+                    val timerItems: List<TimerViewModel.TimerItem<WearableItem>> =
+                        fetchWearablesState.wearables.mapNotNull { wearableItem ->
+                            when (wearableItem.pendingState) {
+                                ItemAdapter.ItemPendingState.NotPending -> null
+                                is ItemAdapter.ItemPendingState.PendingActivation -> TimerViewModel.TimerItem(
+                                    wearableItem,
+                                    (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingActivation).activatedAtTimeInMillis
+                                )
+                                is ItemAdapter.ItemPendingState.PendingRemoval -> TimerViewModel.TimerItem(
+                                    wearableItem,
+                                    (wearableItem.pendingState as ItemAdapter.ItemPendingState.PendingRemoval).removedAtTimeInMillis
+                                )
+                            }
+                        }
+
+                    timerViewModel.startTimers(timerItems)
                 }
-                is WearablesSettingsViewModel.CancelRemoveState.Failure -> requireActivity().onBackPressed()
+                WearablesSettingsViewModel.GetStoredWearablesState.GettingStoredWearables -> {
+                    if (loadingDialogFragment == null) {
+                        ProgressDialogFragment.show(
+                            null,
+                            getString(R.string.ioa_sec_bp_sett_loading),
+                            cancellable = false,
+                            indeterminate = false,
+                            childFragmentManager,
+                            ProgressDialogFragment::class.java.simpleName
+                        )
+                    }
+                }
+                else -> Unit
             }
         }
 
-        wearablesSettingsViewModel.removeState.observe(viewLifecycleOwner) {
-            when (it) {
-                is WearablesSettingsViewModel.RemoveState.Success -> { /* getStoredWearables() called from dialog to refresh list */ }
-                is WearablesSettingsViewModel.RemoveState.Failure -> requireActivity().onBackPressed()
+        wearablesSettingsViewModel.newWearableState.observe(viewLifecycleOwner) { newWearableState ->
+            when (newWearableState) {
+                WearablesSettingsViewModel.NewWearableState.AddingNewWearable -> {
+                    timerViewModel.stopTimers()
+                }
+                else -> Unit
             }
         }
 
-        wearablesSettingsViewModel.removeAllState.observe(viewLifecycleOwner) {
-            // Go back regardless
-            requireActivity().onBackPressed()
+        wearablesSettingsViewModel.removeSingleWearableState.observe(viewLifecycleOwner) { removeSingleWearableState ->
+            when (removeSingleWearableState) {
+                is WearablesSettingsViewModel.RemoveSingleWearableState.CancelledWearableRemoval -> {
+                    timerViewModel.cancelTimerForItem(removeSingleWearableState.wearable)
+                }
+                is WearablesSettingsViewModel.RemoveSingleWearableState.RemovingWearable -> {
+                    val wearableToRemove = removeSingleWearableState.wearable
+                    val header: String
+                    val message: String
+                    if (wearableToRemove.isPendingRemoval) {
+                        header = getString(R.string.ioa_sec_bp_sett_dialog_undoremove_single_title)
+                        message = getString(
+                            R.string.ioa_sec_bp_sett_dialog_undoremoval_message_format,
+                            wearableToRemove.name
+                        )
+                    } else {
+                        header = getString(R.string.ioa_sec_bp_sett_dialog_remove_single_title)
+                        message = getString(
+                            R.string.ioa_sec_bp_sett_dialog_remove_single_message_format,
+                            wearableToRemove.name
+                        )
+                    }
+
+                    GenericAlertDialogFragment.show(
+                        childFragmentManager,
+                        requireContext(),
+                        header,
+                        message,
+                        getString(R.string.ioa_generic_yes),
+                        true,
+                        getString(R.string.ioa_generic_cancel),
+                        REMOVE_SINGLE_TAG
+                    ).setPositiveButtonClickListener { _, _ ->
+                        wearablesSettingsViewModel.removeSelectedWearable()
+                    }
+                }
+                else -> Unit
+            }
+        }
+
+        wearablesSettingsViewModel.removeAllWearablesState.observe(viewLifecycleOwner) { removeAllWearablesState ->
+            if (removeAllWearablesState is WearablesSettingsViewModel.RemoveAllWearablesState.RemovingAllWearables) {
+                GenericAlertDialogFragment.show(
+                    childFragmentManager,
+                    requireContext(),
+                    getString(R.string.ioa_sec_bp_sett_dialog_remove_all_title),
+                    getString(R.string.ioa_sec_bp_sett_dialog_remove_all_messsage),
+                    getString(R.string.ioa_generic_yes),
+                    true,
+                    getString(R.string.ioa_generic_cancel),
+                    REMOVE_ALL_TAG
+                ).setPositiveButtonClickListener { _, _ ->
+                    wearablesSettingsViewModel.removeAllWearables()
+                }
+            }
         }
 
         timerViewModel.state.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is TimerViewModel.State.ItemFinished<*> -> {
-                    // remove or activate the location
+                    // remove or activate the wearable
                     val item = state as TimerViewModel.State.ItemFinished<WearableItem>
                     adapter.notifyTimerFinished(item.timerItem.item)
                 }
                 is TimerViewModel.State.ItemUpdated<*> -> {
-                    // update the location
+                    // update the wearable
                     val item = state as TimerViewModel.State.ItemUpdated<WearableItem>
                     adapter.notifyTimerUpdate(item.timerItem.item, item.remainingMillis)
                 }
                 TimerViewModel.State.AllItemsFinished -> {
-                    wearablesSettingsViewModel.getStoredWearables()
+                    wearablesSettingsViewModel.fetchWearables()
                 }
             }
         }
-
-        with(settingsPanel) {
-            setRemoveText(R.string.ioa_sec_bp_sett_panel_remove_text)
-            setRemoveButtonText(R.string.ioa_sec_bp_sett_panel_remove_button)
-            setOnRemoveButtonClick(onRemoveAllListener)
-            disallowSwitchSwipe()
-            setOnSwitchClickedListener {
-                verificationFlagViewModel.toggleVerificationFlag(
-                        if (isSwitchOn) VerificationFlag.State.ALWAYS
-                        else VerificationFlag.State.WHEN_REQUIRED
-                )
-            }
-        }
-        loadingDialog!!.show(childFragmentManager, ProgressDialogFragment::class.java.simpleName)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val id = item.itemId
-        if (R.id.bluetooth_add == id) {
-            (requireParentFragment() as WearablesFragment).goToAdd(true)
-            return true
-        }
-        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsViewModel.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/auth_method/wearables/WearablesSettingsViewModel.kt
@@ -1,119 +1,209 @@
 package com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables
 
 import androidx.lifecycle.*
-import com.launchkey.android.authenticator.sdk.core.auth_method_management.LocationsManager
-import com.launchkey.android.authenticator.sdk.core.auth_method_management.VerificationFlag
 import com.launchkey.android.authenticator.sdk.core.auth_method_management.WearablesManager
 import com.launchkey.android.authenticator.sdk.ui.internal.util.TimingCounter
 import com.launchkey.android.authenticator.sdk.ui.internal.util.disposeWhenCancelled
 import com.launchkey.android.authenticator.sdk.ui.internal.viewmodel.SingleLiveEvent
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.*
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-class WearablesSettingsViewModel(private val wearablesManager: WearablesManager,
-                                 private val nowProvider: TimingCounter.NowProvider,
-                                 private val defaultDispatcher: CoroutineDispatcher,
-                                 savedStateHandle: SavedStateHandle) : ViewModel() {
-    private val _getStoredWearablesState: MutableLiveData<GetStoredWearablesState> = MutableLiveData()
-    val getStoredWearablesState: LiveData<GetStoredWearablesState> = _getStoredWearablesState
+class WearablesSettingsViewModel(
+    private val wearablesManager: WearablesManager,
+    private val nowProvider: TimingCounter.NowProvider,
+    private val defaultDispatcher: CoroutineDispatcher,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val _newWearableState = SingleLiveEvent<NewWearableState>()
+    val newWearableState: LiveData<NewWearableState>
+        get() = _newWearableState
 
-    private val _cancelRemoveState: MutableLiveData<CancelRemoveState> = SingleLiveEvent()
-    val cancelRemoveState: LiveData<CancelRemoveState> = _cancelRemoveState
+    private val _getStoredWearablesState = MutableLiveData<GetStoredWearablesState>()
+    val getStoredWearablesState: LiveData<GetStoredWearablesState>
+        get() = _getStoredWearablesState
 
-    private val _removeState: MutableLiveData<RemoveState> = SingleLiveEvent()
-    val removeState: LiveData<RemoveState> = _removeState
+    private val _removeSingleWearableState = SingleLiveEvent<RemoveSingleWearableState>()
+    val removeSingleWearableState: LiveData<RemoveSingleWearableState>
+        get() = _removeSingleWearableState
 
-    private val _removeAllState: MutableLiveData<RemoveAllState> = SingleLiveEvent()
-    val removeAllState: LiveData<RemoveAllState> = _removeAllState
+    private val _removeAllWearablesState = SingleLiveEvent<RemoveAllWearablesState>()
+    val removeAllWearablesState: LiveData<RemoveAllWearablesState>
+        get() = _removeAllWearablesState
+
+    private lateinit var wearableToRemove: WearablesManager.Wearable
+    private var getStoredWearablesJob: Job? = null
 
     init {
-        getStoredWearables()
+        fetchWearables()
     }
 
-    private suspend fun getStoredWearablesAsync() = suspendCancellableCoroutine<List<WearablesManager.Wearable>> { continuation ->
-        wearablesManager.getStoredWearables(object : WearablesManager.GetStoredWearablesCallback {
-            override fun onGetSuccess(wearables: MutableList<WearablesManager.Wearable>) {
-                continuation.resume(wearables)
-            }
+    private suspend fun getAllWearables() =
+        suspendCancellableCoroutine<List<WearablesManager.Wearable>> { continuation ->
+            wearablesManager.getStoredWearables(object :
+                WearablesManager.GetStoredWearablesCallback {
+                override fun onGetSuccess(wearables: MutableList<WearablesManager.Wearable>) {
+                    continuation.resume(wearables)
+                }
 
-            override fun onGetFailure(e: Exception) {
-                continuation.resumeWithException(e)
-            }
-        }).disposeWhenCancelled(continuation)
-    }
+                override fun onGetFailure(e: Exception) {
+                    continuation.resumeWithException(e)
+                }
+            }).disposeWhenCancelled(continuation)
+        }
 
-    fun getStoredWearables() = viewModelScope.launch(defaultDispatcher) {
-        try {
-            _getStoredWearablesState.postValue(GetStoredWearablesState.Success(getStoredWearablesAsync().map { WearableItem(it, nowProvider.now) }))
-        } catch (exception: Exception) {
-            _getStoredWearablesState.postValue(GetStoredWearablesState.Failure(exception))
+    fun fetchWearables() {
+        getStoredWearablesJob?.let {
+            if (it.isActive) {
+                return
+            }
+        }
+
+        getStoredWearablesJob = viewModelScope.launch(defaultDispatcher) {
+            _getStoredWearablesState.postValue(GetStoredWearablesState.GettingStoredWearables)
+            try {
+                val wearables = getAllWearables().map {
+                    WearableItem(it, nowProvider.now)
+                }
+                _getStoredWearablesState.postValue(
+                    GetStoredWearablesState.GotStoredWearables(wearables)
+                )
+            } catch (e: Exception) {
+                _getStoredWearablesState.postValue(GetStoredWearablesState.Failed(e))
+            }
         }
     }
 
-    fun cancelRemoveWearable(wearable: WearablesManager.Wearable) = viewModelScope.launch(defaultDispatcher) {
-        wearablesManager.cancelRemoveWearable(wearable, object : WearablesManager.CancelRemoveWearableCallback {
-            override fun onCancelRemoveSuccess() {
-                _cancelRemoveState.postValue(CancelRemoveState.Success(WearableItem(wearable, nowProvider.now)))
-                getStoredWearables()
-            }
-            override fun onCancelRemoveFailure(e: Exception) {
-                _cancelRemoveState.postValue(CancelRemoveState.Failure(e))
-            }
-        })
+    fun requestNewWearable() {
+        _newWearableState.postValue(NewWearableState.AddingNewWearable)
     }
 
-    fun removeWearable(wearable: WearablesManager.Wearable) {
-        wearablesManager.removeWearable(wearable, object : WearablesManager.RemoveWearableCallback {
-            override fun onRemoveSuccess() {
-                _removeState.postValue(RemoveState.Success(WearableItem(wearable, nowProvider.now)))
-                getStoredWearables()
-            }
-            override fun onRemoveFailure(e: Exception) {
-                _removeState.postValue(RemoveState.Failure(e))
-            }
-        })
+    fun addedNewWearable() {
+        if (_newWearableState.value!! !is NewWearableState.AddedNewWearable) {
+            _newWearableState.postValue(NewWearableState.AddedNewWearable)
+        }
     }
 
-    fun removeAllWearables() = viewModelScope.launch(defaultDispatcher) {
-        try {
-            getStoredWearablesAsync().forEach {
-                try {
-                    if (!it.isPendingRemoval) {
-                        removeWearable(it)
+    private fun removeWearable(wearable: WearablesManager.Wearable) {
+        viewModelScope.launch {
+            try {
+                if (wearable.isPendingRemoval) {
+                    cancelRemoveWearable(wearable)
+                    _removeSingleWearableState.postValue(
+                        RemoveSingleWearableState.CancelledWearableRemoval(wearable)
+                    )
+                } else {
+                    removeSingleWearable(wearable)
+                    _removeSingleWearableState.postValue(
+                        RemoveSingleWearableState.PendingWearableRemoval(wearable)
+                    )
+                }
+                fetchWearables()
+            } catch (e: Exception) {
+                _removeSingleWearableState.postValue(RemoveSingleWearableState.Failed(e))
+            }
+        }
+    }
+
+    fun removeSelectedWearable() {
+        removeWearable(wearableToRemove)
+    }
+
+    fun setWearableToRemove(wearable: WearablesManager.Wearable) {
+        wearableToRemove = wearable
+        _removeSingleWearableState.postValue(
+            RemoveSingleWearableState.RemovingWearable(wearable)
+        )
+    }
+
+    private suspend fun removeSingleWearable(wearable: WearablesManager.Wearable) =
+        suspendCancellableCoroutine<Exception?> { continuation ->
+            wearablesManager.removeWearable(wearable,
+                object : WearablesManager.RemoveWearableCallback {
+                    override fun onRemoveSuccess() {
+                        continuation.resume(null)
                     }
-                } catch (exception: Exception) {
-                    _removeAllState.postValue(RemoveAllState.Failure(exception))
-                    cancel()
-                    return@launch
+
+                    override fun onRemoveFailure(e: Exception) {
+                        continuation.resumeWithException(e)
+                    }
+                }).disposeWhenCancelled(continuation)
+        }
+
+    private suspend fun cancelRemoveWearable(wearable: WearablesManager.Wearable) =
+        suspendCancellableCoroutine<Exception?> { continuation ->
+            wearablesManager.cancelRemoveWearable(wearable,
+                object : WearablesManager.CancelRemoveWearableCallback {
+                    override fun onCancelRemoveSuccess() {
+                        continuation.resume(null)
+                    }
+
+                    override fun onCancelRemoveFailure(e: Exception) {
+                        continuation.resumeWithException(e)
+                    }
+                })
+        }
+
+    fun requestRemoveAllWearables() {
+        _removeAllWearablesState.postValue(RemoveAllWearablesState.RemovingAllWearables)
+    }
+
+    fun removeAllWearables() {
+        viewModelScope.launch(defaultDispatcher) {
+            val wearables: List<WearablesManager.Wearable>
+            try {
+                wearables = getAllWearables()
+            } catch (exception: Exception) {
+                _removeAllWearablesState.postValue(RemoveAllWearablesState.Failed(exception))
+                return@launch
+            }
+
+            launch {
+                wearables.forEach { wearable ->
+                    try {
+                        if (!wearable.isPendingRemoval) {
+                            removeSingleWearable(wearable)
+                        }
+                    } catch (e: Exception) {
+                        _removeAllWearablesState.postValue(RemoveAllWearablesState.Failed(e))
+                        cancel()
+                    }
+                }
+            }.invokeOnCompletion {
+                if (it == null) {
+                    _removeAllWearablesState.postValue(RemoveAllWearablesState.PendingRemovalForAllWearables)
                 }
             }
-            _removeAllState.postValue(RemoveAllState.Success())
-        } catch (exception: Exception) {
-            _removeAllState.postValue(RemoveAllState.Failure(exception))
         }
     }
 
     sealed class GetStoredWearablesState {
-        data class Success(val wearables: List<WearableItem>) : GetStoredWearablesState()
-        data class Failure(val exception: Exception) : GetStoredWearablesState()
+        object GettingStoredWearables : GetStoredWearablesState()
+        data class GotStoredWearables(val wearables: List<WearableItem>) : GetStoredWearablesState()
+        data class Failed(val failure: Exception) : GetStoredWearablesState()
     }
 
-    sealed class RemoveState {
-        data class Success(val wearable: WearableItem) : RemoveState()
-        data class Failure(val exception: Exception) : RemoveState()
+    sealed class RemoveAllWearablesState {
+        object RemovingAllWearables : RemoveAllWearablesState()
+        object PendingRemovalForAllWearables : RemoveAllWearablesState()
+        data class Failed(val failure: Exception) : RemoveAllWearablesState()
     }
 
-    sealed class CancelRemoveState {
-        data class Success(val wearable: WearableItem) : CancelRemoveState()
-        data class Failure(val exception: Exception) : CancelRemoveState()
+    sealed class RemoveSingleWearableState {
+        data class RemovingWearable(val wearable: WearablesManager.Wearable) :
+            RemoveSingleWearableState()
+
+        data class PendingWearableRemoval(val wearable: WearablesManager.Wearable) :
+            RemoveSingleWearableState()
+
+        data class CancelledWearableRemoval(val wearable: WearablesManager.Wearable) :
+            RemoveSingleWearableState()
+
+        data class Failed(val exception: Exception) : RemoveSingleWearableState()
     }
 
-    sealed class RemoveAllState {
-        class Success : RemoveAllState()
-        data class Failure(val exception: Exception) : RemoveAllState()
+    sealed class NewWearableState {
+        object AddingNewWearable : NewWearableState()
+        object AddedNewWearable : NewWearableState()
     }
 }

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/dialog/SetNameDialogFragment.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/dialog/SetNameDialogFragment.kt
@@ -19,9 +19,14 @@ class SetNameDialogFragment : AlertDialogFragment() {
     private var defaultTextValue: String? = null
     private var setNameListener: SetNameListener? = null
     private val binding: DialogFragmentSetnameBinding by viewBinding(DialogFragmentSetnameBinding::bind)
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
         val binding = DialogFragmentSetnameBinding.inflate(
-                LayoutInflater.from(requireActivity()), null, false)
+            LayoutInflater.from(requireActivity()), null, false
+        )
         val arguments = arguments
         if (arguments != null) {
             hint = arguments.getString(HINT_ARG)
@@ -37,7 +42,8 @@ class SetNameDialogFragment : AlertDialogFragment() {
         editText.setOnEditorActionListener(OnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE) {
                 if (dialog != null && dialog is AlertDialog) {
-                    val positiveButton = (dialog as AlertDialog?)!!.getButton(AlertDialog.BUTTON_POSITIVE)
+                    val positiveButton =
+                        (dialog as AlertDialog?)!!.getButton(AlertDialog.BUTTON_POSITIVE)
                     positiveButton?.performClick()
                     return@OnEditorActionListener true
                 }
@@ -90,23 +96,28 @@ class SetNameDialogFragment : AlertDialogFragment() {
     companion object {
         private const val HINT_ARG = "hint"
         private const val DEFAULT_TEXT_ARG = "default_text"
+
         @Deprecated(message = "Use alternative show method with corresponding viewmodel")
         @JvmStatic
         fun show(
-                context: Context,
-                fm: FragmentManager,
-                titleResourceId: Int,
-                hintRes: Int,
-                positiveButtonTextRes: Int,
-                defaultValue: String?,
-                onNameSet: SetNameListener?,
-                onCancel: DialogInterface.OnCancelListener?,
-                cancellable: Boolean): SetNameDialogFragment {
-            
+            context: Context,
+            fm: FragmentManager,
+            titleResourceId: Int,
+            hintRes: Int,
+            positiveButtonTextRes: Int,
+            defaultValue: String?,
+            onNameSet: SetNameListener?,
+            onCancel: DialogInterface.OnCancelListener?,
+            cancellable: Boolean
+        ): SetNameDialogFragment {
+
             val arguments = Bundle()
             arguments.putString(TITLE_ARG, context.getString(titleResourceId))
             arguments.putString(POSITIVE_BUTTON_ARG, context.getString(positiveButtonTextRes))
-            arguments.putString(NEGATIVE_BUTTON_TEXT_ARG, context.getString(R.string.ioa_generic_cancel))
+            arguments.putString(
+                NEGATIVE_BUTTON_TEXT_ARG,
+                context.getString(R.string.ioa_generic_cancel)
+            )
             arguments.putString(HINT_ARG, context.getString(hintRes))
             arguments.putString(DEFAULT_TEXT_ARG, defaultValue)
             arguments.putBoolean(CANCELLABLE_ARG, cancellable)
@@ -117,24 +128,26 @@ class SetNameDialogFragment : AlertDialogFragment() {
             dialog.show(fm, SetNameDialogFragment::class.java.simpleName)
             return dialog
         }
+
+        @JvmStatic
         fun show(
-                context: Context,
-                fm: FragmentManager,
-                titleResourceId: Int,
-                hintRes: Int,
-                positiveButtonTextRes: Int,
-                defaultValue: String?): SetNameDialogFragment? {
-            val arguments = Bundle()
-            arguments.putString(TITLE_ARG, context.getString(titleResourceId))
-            arguments.putString(POSITIVE_BUTTON_ARG, context.getString(positiveButtonTextRes))
-            arguments.putString(NEGATIVE_BUTTON_TEXT_ARG, context.getString(R.string.ioa_generic_cancel))
-            arguments.putString(HINT_ARG, context.getString(hintRes))
-            arguments.putString(DEFAULT_TEXT_ARG, defaultValue)
-            arguments.putBoolean(CANCELLABLE_ARG, false)
-            val dialog = SetNameDialogFragment()
-            dialog.arguments = arguments
-            dialog.show(fm, SetNameDialogFragment::class.java.simpleName)
-            return dialog
+            context: Context,
+            fragmentManager: FragmentManager,
+            titleResourceId: Int,
+            hintRes: Int,
+            positiveButtonTextRes: Int,
+            defaultValue: String?,
+            tag: String = SetNameDialogFragment::class.java.simpleName
+        ): SetNameDialogFragment = SetNameDialogFragment().apply {
+            arguments = Bundle().apply {
+                putString(TITLE_ARG, context.getString(titleResourceId))
+                putString(POSITIVE_BUTTON_ARG, context.getString(positiveButtonTextRes))
+                putString(NEGATIVE_BUTTON_TEXT_ARG, context.getString(R.string.ioa_generic_cancel))
+                putString(HINT_ARG, context.getString(hintRes))
+                putString(DEFAULT_TEXT_ARG, defaultValue)
+                putBoolean(CANCELLABLE_ARG, false)
+            }
+            show(fragmentManager, tag)
         }
     }
 }

--- a/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/util/BaseAppCompatFragment.kt
+++ b/app/src/main/java/com/launchkey/android/authenticator/sdk/ui/internal/util/BaseAppCompatFragment.kt
@@ -19,15 +19,15 @@ import com.launchkey.android.authenticator.sdk.core.authentication_management.Au
 import com.launchkey.android.authenticator.sdk.ui.AuthenticatorUIManager
 import com.launchkey.android.authenticator.sdk.ui.fragment.DevicesViewModel
 import com.launchkey.android.authenticator.sdk.ui.fragment.SessionsViewModel
+import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.TimerViewModel
+import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.VerificationFlagViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.biometric.BiometricAddViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.biometric.BiometricCheckViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.circle_code.CircleCodeAddViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.circle_code.CircleCodeCheckViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.locations.LocationsAddViewModel
-import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.locations.LocationsSettingsViewModel
-import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.VerificationFlagViewModel
-import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.TimerViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.locations.LocationsAsyncVerificationFlagManager
+import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.locations.LocationsSettingsViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.locations.location_tracker.LocationTrackerFactory
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.locations.map.MapViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.locations.map.MapViewModel.Companion.GEO_FENCE_FILL_ALPHA
@@ -37,13 +37,13 @@ import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.pin_code.
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.pin_code.PinCodeCheckViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables.WearablesAddViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables.WearablesAsyncVerificationFlagManager
+import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables.WearablesScanViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_method.wearables.WearablesSettingsViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_request.AuthRequestFragmentViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.auth_request.verify.AuthRequestVerificationViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.dialog.DialogFragmentViewModel
 import com.launchkey.android.authenticator.sdk.ui.internal.viewmodel.SecurityViewModel
 import kotlinx.coroutines.Dispatchers
-import java.util.concurrent.Executors
 
 abstract class BaseAppCompatFragment : Fragment {
     private val viewModelProviderFactory: ViewModelProvider.Factory by lazy {
@@ -102,38 +102,38 @@ abstract class BaseAppCompatFragment : Fragment {
                         DialogFragmentViewModel(handle) as T
                     PinCodeAddViewModel::class.java ->
                         PinCodeAddViewModel(
-                                AuthMethodManagerFactory.getPINCodeManager(),
-                                PINCodeRequirement.pinCodeRequirements,
-                                handle
+                            AuthMethodManagerFactory.getPINCodeManager(),
+                            PINCodeRequirement.pinCodeRequirements,
+                            handle
                         ) as T
                     PinCodeCheckViewModel::class.java ->
                         PinCodeCheckViewModel(
-                                AuthMethodManagerFactory.getPINCodeManager(),
-                                AuthenticatorManager.instance.config.thresholdAutoUnlink(),
-                                handle
+                            AuthMethodManagerFactory.getPINCodeManager(),
+                            AuthenticatorManager.instance.config.thresholdAutoUnlink(),
+                            handle
                         ) as T
                     CircleCodeAddViewModel::class.java ->
                         CircleCodeAddViewModel(
-                                AuthMethodManagerFactory.getCircleCodeManager(),
-                                handle
+                            AuthMethodManagerFactory.getCircleCodeManager(),
+                            handle
                         ) as T
                     CircleCodeCheckViewModel::class.java ->
                         CircleCodeCheckViewModel(
-                                AuthMethodManagerFactory.getCircleCodeManager(),
-                                AuthenticatorManager.instance.config.thresholdAutoUnlink(),
-                                handle
+                            AuthMethodManagerFactory.getCircleCodeManager(),
+                            AuthenticatorManager.instance.config.thresholdAutoUnlink(),
+                            handle
                         ) as T
                     BiometricAddViewModel::class.java ->
                         BiometricAddViewModel(
-                                AuthMethodManagerFactory.getBiometricManager(),
-                                Dispatchers.IO,
-                                handle
+                            AuthMethodManagerFactory.getBiometricManager(),
+                            Dispatchers.IO,
+                            handle
                         ) as T
                     BiometricCheckViewModel::class.java ->
                         BiometricCheckViewModel(
-                                AuthMethodManagerFactory.getBiometricManager(),
-                                AuthenticatorManager.instance.config.thresholdAutoUnlink(),
-                                handle
+                            AuthMethodManagerFactory.getBiometricManager(),
+                            AuthenticatorManager.instance.config.thresholdAutoUnlink(),
+                            handle
                         ) as T
                     MapViewModel::class.java -> {
                         val strokeColor =
@@ -144,7 +144,7 @@ abstract class BaseAppCompatFragment : Fragment {
                             Color.green(strokeColor),
                             Color.blue(strokeColor)
                         )
-        
+
                         return MapViewModel(
                             strokeColor,
                             fillColor,
@@ -153,16 +153,16 @@ abstract class BaseAppCompatFragment : Fragment {
                     }
                     LocationsAddViewModel::class.java ->
                         LocationsAddViewModel(
-                                AuthMethodManagerFactory.getLocationsManager(),
-                                Dispatchers.IO,
-                                handle
+                            AuthMethodManagerFactory.getLocationsManager(),
+                            Dispatchers.IO,
+                            handle
                         ) as T
                     LocationsSettingsViewModel::class.java ->
                         LocationsSettingsViewModel(
-                                AuthMethodManagerFactory.getLocationsManager(),
-                                TimingCounter.DefaultTimeProvider(),
-                                Dispatchers.IO,
-                                handle
+                            AuthMethodManagerFactory.getLocationsManager(),
+                            TimingCounter.DefaultTimeProvider(),
+                            Dispatchers.IO,
+                            handle
                         ) as T
                     UserLocationViewModel::class.java ->
                         UserLocationViewModel(
@@ -172,8 +172,12 @@ abstract class BaseAppCompatFragment : Fragment {
                     VerificationFlagViewModel::class.java ->
                         VerificationFlagViewModel(
                             when (key) {
-                                VerificationFlagViewModel.LOCATIONS -> LocationsAsyncVerificationFlagManager(AuthMethodManagerFactory.getLocationsManager())
-                                VerificationFlagViewModel.WEARABLES -> WearablesAsyncVerificationFlagManager(AuthMethodManagerFactory.getWearablesManager())
+                                VerificationFlagViewModel.LOCATIONS -> LocationsAsyncVerificationFlagManager(
+                                    AuthMethodManagerFactory.getLocationsManager()
+                                )
+                                VerificationFlagViewModel.WEARABLES -> WearablesAsyncVerificationFlagManager(
+                                    AuthMethodManagerFactory.getWearablesManager()
+                                )
                                 else -> throw IllegalArgumentException("Unkown auth method")
                             },
                             TimingCounter.DefaultTimeProvider(),
@@ -182,16 +186,20 @@ abstract class BaseAppCompatFragment : Fragment {
                         ) as T
                     WearablesAddViewModel::class.java ->
                         WearablesAddViewModel(
-                                AuthMethodManagerFactory.getWearablesManager(),
-                                Executors.newSingleThreadExecutor(),
-                                handle
+                            AuthMethodManagerFactory.getWearablesManager(),
+                            Dispatchers.IO
+                        ) as T
+                    WearablesScanViewModel::class.java ->
+                        WearablesScanViewModel(
+                            AuthMethodManagerFactory.getWearablesManager(),
+                            Dispatchers.IO,
                         ) as T
                     WearablesSettingsViewModel::class.java ->
                         WearablesSettingsViewModel(
-                                AuthMethodManagerFactory.getWearablesManager(),
-                                TimingCounter.DefaultTimeProvider(),
-                                Dispatchers.IO,
-                                handle
+                            AuthMethodManagerFactory.getWearablesManager(),
+                            TimingCounter.DefaultTimeProvider(),
+                            Dispatchers.IO,
+                            handle
                         ) as T
                     TimerViewModel::class.java ->
                         TimerViewModel(
@@ -206,24 +214,24 @@ abstract class BaseAppCompatFragment : Fragment {
             }
         }
     }
-    
+
     constructor() : super()
     constructor(@LayoutRes layoutId: Int) : super(layoutId)
-    
+
     override fun getDefaultViewModelProviderFactory(): ViewModelProvider.Factory {
         return viewModelProviderFactory
     }
-    
+
     override fun startActivity(intent: Intent) {
         IntentUtils.addInternalVerification(intent)
         super.startActivity(intent)
     }
-    
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         UiUtils.themeStatusBar(activity)
     }
-    
+
     /**
      * Method to potentially unmask a request code modified by v4 Support Fragment/Activity to
      * redirect result back to the right fragment after


### PR DESCRIPTION
* Fix title not displaying when in add or settings wearables page.
Formatted WearablesFragment.kt.

* Fixed toolbar clearing after configuration change.

* Fix Bluetooth Disabled Dialog (#3)

* Removed disabled bluetooth viewmodels and simplified the alert dialog logic.
Formatted WearablesAddViewModel.kt

* Refactored Add Wearables Screen (#4)

* Moved DiscoveredWearablesAdapter to separate class.

* Added Scanning Devices state to AvailableWearablesState.
Added additional states when naming wearable.
Formatted SetNameDialogFragment.kt.

* Moved wearables scanning logic and state to new WearablesScanViewModel.
No longer holding wearables list in WearablesAddFragment.
Made DiscoveredWearablesAdapter a ListAdapter.

* SetNameDialogFragment now accepts a configurable default tag.
WearablesAddViewModel now uses Dispatchers.IO instead of an executor.
WearablesAddViewModel no longer uses the savedStateHandle and holds the currently selected wearable.
Fixed getting the wrong SetNameDialogFragment after successfully or failing to add a wearable.
WearablesFragment now listens to the state of WearablesAddViewModel.

* Fixed title not being re-set.

* refactor settings wearables screen (#5)

* Formatted WearablesSettingsViewModel.

* Refactored WearablesSettings to be identical to LocationsSettings.
These pages/viewmodels may be generified and reused instead.